### PR TITLE
Add Windows support for GetEconItemViewFromWeapon

### DIFF
--- a/PTaH.games.txt
+++ b/PTaH.games.txt
@@ -30,10 +30,10 @@
 				"windows"		"\x55\x8B\xEC\x8B\x45\x08\x83\xF8\x04\x7C\x2A\x8B\x81\x2A\x2A\x2A\x2A\x5D\xC2"
 				"linux"			"@_ZNK24CCStrike15ItemDefinition14GetLoadoutSlotEi"
 			}
+			// Inlined on Windows. Get it from the CBaseCombatWeapon offset.
 			"GetEconItemViewFromWeapon"
 			{
 				"library"		"server"
-				"windows"		""
 				"linux"			"@_ZNK17CBaseCombatWeapon15GetEconItemViewEv"
 			}
 		}
@@ -138,6 +138,11 @@
 			{
 				"windows"		"33"
 				"linux"			"34"
+			}
+			"CBaseCombatWeapon::m_hEconItemView"
+			{
+				"windows"		"1768"
+				"linux"			"1788"
 			}
 		}
 	}

--- a/natives.cpp
+++ b/natives.cpp
@@ -219,7 +219,20 @@ static cell_t PTaH_GetEconItemViewFromWeapon(IPluginContext *pContext, const cel
 	{
 		return pContext->ThrowNativeError("Entity %d is not weapon", params[1]);
 	}
+
+#ifdef WIN32
+	static int offset = 0;
 	
+	if (offset == 0 && !g_pGameConf[GameConf_PTaH]->GetOffset("CBaseCombatWeapon::m_hEconItemView", &offset))
+	{
+		smutils->LogError(myself, "Failed to find offset for CBaseCombatWeapon::m_hEconItemView");
+		return 0;
+	}
+	
+	CEconItemView *pView = (CEconItemView *)((uint8 *)pEntity + offset);
+	
+	return (cell_t)pView;
+#else
 	static ICallWrapper *pCallWrapper = nullptr;
 	if(!pCallWrapper)
 	{
@@ -248,6 +261,7 @@ static cell_t PTaH_GetEconItemViewFromWeapon(IPluginContext *pContext, const cel
 	CEconItemView *pView = nullptr;
 	pCallWrapper->Execute(vstk, &pView);
 	return (cell_t)pView;
+#endif
 }
 
 static cell_t PTaH_GetCustomPaintKitIndex(IPluginContext *pContext, const cell_t *params)


### PR DESCRIPTION
The function `CBaseCombatWeapon::GetEconItemView` is inlined on Windows and must be grabbed directly from the member variable with an offset. This should fix the issue for CS:GO.
