### PR TITLE
Update 1.0.8

### DIFF
--- a/PTaH.games.txt
+++ b/PTaH.games.txt
@@ -16,13 +16,7 @@
 				"windows"		"\x55\x8B\xEC\x81\xEC\x0C\x05\x00\x00\x56"
 				"linux"			"\x55\x89\xE5\x83\xEC\x18\x89\x5D\xF8\x8B\x5D\x08\x89\x75\xFC\x8B\x75\x0C\x89\x1C\x24\x89\x74\x24\x04\xE8\x2A\x2A\x2A\x2A\x84\xC0\x74\x2A" //Thank you Peace-Maker | _ZN11CGameClient20ExecuteStringCommandEPKc
 			}
-			"GetItemSchema"
-			{
-				"library"		"server"
-				"windows"		"\xA1\x2A\x2A\x2A\x2A\x85\xC0\x75\x2A\xA1\x2A\x2A\x2A\x2A\x56"
-				"linux"			"\x55\x89\xE5\x83\xEC\x08\xE8\x2A\x2A\x2A\x2A\xC9\x83\xC0\x04\xC3" //_Z13GetItemSchemav
-			}
-			//CCStrike15ItemDefinition__GetLoadoutSlot(CCStrike15ItemDefinition *this, int def)
+			//CCStrike15ItemDefinition__GetLoadoutSlot(CCStrike15ItemDefinition *this, int team)
 			//CEconItemDefinition::GetLoadoutSlot() - does not work, always returns 0
 			"GetLoadoutSlot"
 			{
@@ -30,23 +24,11 @@
 				"windows"		"\x55\x8B\xEC\x8B\x45\x08\x8D\x50\xFF"
 				"linux"			"\x55\x89\xE5\x8B\x45\x0C\x8B\x55\x08\x8D\x48\xFF" //_ZNK24CCStrike15ItemDefinition14GetLoadoutSlotEi
 			}
-			"SpawnItem"
-			{
-				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x51\x53\x56\x57\xE8\x2A\x2A\x2A\x2A\x8B\x5D\x08"
-				"linux"			"\x55\x89\xE5\x57\x56\x53\x83\xEC\x4C\x8B\x55\x08\x8B\x7D\x0C\x8B\x5D\x20" //_ZN15CItemGeneration9SpawnItemEiRK6VectorRK6QAngleiiPKc
-			}
 			"FindMatchingWeaponsForTeamLoadout"
 			{
 				"library"		"server"
 				"windows"		"\x55\x8B\xEC\x83\xEC\x08\x53\x56\x57\x89\x4D\xF8"
 				"linux"			"\x55\x89\xE5\x57\x56\x53\x83\xEC\x3C\x0F\xB6\x4D\x14" //_ZN9CCSPlayer33FindMatchingWeaponsForTeamLoadoutEPKcibR10CUtlVectorIP13CEconItemView10CUtlMemoryIS4_iEE
-			}
-			"GetCCSWeaponDataFromDef"
-			{
-				"library"		"server"
-				"windows"		"\x8B\x01\x56\x8B\x35\x2A\x2A\x2A\x2A\xFF\x10\x0F\xB7\xC0\xB9\x2A\x2A\x2A\x2A\x50\xFF\x56\x08\x5E\xC3"
-				"linux"			"\x55\x31\xC0\x89\xE5\x53\x83\xEC\x14\x8B\x55\x08\x85\xD2"
 			}
 		}
 		"Keys"
@@ -69,15 +51,15 @@
 				"windows"		"52"
 				"linux"			"53"
 			}
-			"GetItemDefintionByName"
-			{
-				"windows"		"42"
-				"linux"			"41"
-			}
 			"GetItemDefinitionByDefIndex"
 			{
 				"windows"		"208"
 				"linux"			"208"
+			}
+			"GetAttributeDefinitionInterface"
+			{
+				"windows"		"27"
+				"linux"			"27"
 			}
 			"GetDefinitionIndex"
 			{
@@ -164,11 +146,11 @@
 				"windows"		"22"
 				"linux"			"23"
 			}
-			//"GetKillEaterValueByType" removed Valve 8/17/2017
-			//{
-			//	"windows"		"33"
-			//	"linux"			"34"
-			//}
+			"IterateAttributes"
+			{
+				"windows"		"25"
+				"linux"			"26"
+			}
 		}
 	}
 }

--- a/PTaH.inc
+++ b/PTaH.inc
@@ -85,13 +85,13 @@ methodmap CEconItemDefinition
 	
 	/**
 	 *	Gets LoadoutSlot.
-	 * @param def		default value.
+	 * @param iTeam		Index Commands.
 	 *	-
 	 * @return	Returns LoadoutSlot.
 	 *	-
 	 * @error CEconItemDefinition == NULL.
 	*/
-	public native int GetLoadoutSlot(int def = -1);
+	public native int GetLoadoutSlot(int iTeam = -1);
 	
 	/**
 	 *	Gets the amount slots for Sticker.
@@ -112,15 +112,6 @@ methodmap CEconItemDefinition
 	 * @error CEconItemDefinition == NULL.
 	*/
 	public native int GetClassName(char[] sBuf, int iLen);
-	
-	/**
-	 *	Gets CCSWeaponData.
-	 *	-
-	 * @return	Returns CCSWeaponData.
-	 *	-
-	 * @error CEconItemDefinition == NULL.
-	*/
-	public native Address GetCCSWeaponData();
 };
 
 methodmap CEconItemView
@@ -231,7 +222,7 @@ methodmap CEconItemView
 	*/
 	public bool IsCustomItemView() 
     { 
-		return this.GetAccountID() != 0 ? true:false;
+		return this.GetAccountID() != 0;
     }
 	
 	/**
@@ -288,7 +279,7 @@ methodmap CEconItemView
 	 *	-
 	 * @error CEconItemView == NULL.
 	*/
-	//public native int GetStatTrakKill(); - removed Valve 8/17/2017
+	public native int GetStatTrakKill();
 };
 
 methodmap AddrInfo
@@ -450,7 +441,7 @@ typeset PTaHCB
 	*/
 	function Action (const char[] sName, char sPassword[128], const char[] sIp, const char[] sSteamID, char rejectReason[512]);
 	
-	/** ServerConsolePrint
+	/** ServerConsolePrint (Messages that are in another thread are ignored)
 	 *
 	 *	Called before displaying a message in the server console (Be careful with the messages).
 	 *	-
@@ -461,6 +452,15 @@ typeset PTaHCB
 	*/
 	function Action (const char[] sMessage, LoggingSeverity severity);
 };
+
+/**
+ *	PTaH Version.
+ * @param sBuffer				The string will be written version (only need to specify if you want to get the version as a string).
+ * @param len					Length of the line.
+ *	-
+ * @return	Return PTaH Version (or example 108, sBuffer = "1.0.8").
+*/
+native int PTaH_Version(char[] sBuf = NULL_STRING, int iLen = 0);
 
 /**
  *	Enables Hook.
@@ -523,16 +523,6 @@ native CEconItemView PTaH_GetEconItemViewFromWeapon(int iEnt);
 native int PTaH_GivePlayerItem(int iClient, const char[] sClassname, CEconItemView Item);
 
 /**
- *	Spawn item by DefinitionIndex (CEconItemView valid, so the weapon does not have bugs).
- * @param DefIndex				DefinitionIndex items.
- * @param origin				origin, или NULL_VECTOR.
- * @param angles				angles, или NULL_VECTOR.
- *	-
- * @return	Returns index items.
-*/
-native int PTaH_SpawnItemFromDefIndex(int DefIndex, const float origin[3] = NULL_VECTOR, const float angles[3] = NULL_VECTOR);
-
-/**
  *	gets md5 hash file.
  * @param sFile					The path to the file.
  * @param sBuffer				The string will be recorded hash.
@@ -583,6 +573,7 @@ public Extension __ext_PTaH =
 #if !defined REQUIRE_EXTENSIONS
 public __ext_PTaH_SetNTVOptional()
 {
+	MarkNativeAsOptional("PTaH_Version");
 	MarkNativeAsOptional("PTaH");
 	MarkNativeAsOptional("PTaH_GetItemDefinitionByName");
 	MarkNativeAsOptional("PTaH_GetItemDefinitionByDefIndex");
@@ -590,7 +581,6 @@ public __ext_PTaH_SetNTVOptional()
 	MarkNativeAsOptional("CEconItemDefinition.GetLoadoutSlot");
 	MarkNativeAsOptional("CEconItemDefinition.GetNumSupportedStickerSlots");
 	MarkNativeAsOptional("CEconItemDefinition.GetClassName");
-	MarkNativeAsOptional("CEconItemDefinition.GetCCSWeaponData");
 	MarkNativeAsOptional("PTaH_GetItemInLoadout");
 	MarkNativeAsOptional("PTaH_GetEconItemViewFromWeapon");
 	MarkNativeAsOptional("CEconItemView.GetCustomPaintKitIndex");
@@ -608,7 +598,6 @@ public __ext_PTaH_SetNTVOptional()
 	MarkNativeAsOptional("CEconItemView.GetCustomName");
 	MarkNativeAsOptional("CEconItemView.GetStatTrakKill");
 	MarkNativeAsOptional("PTaH_GivePlayerItem");
-	MarkNativeAsOptional("PTaH_SpawnItemFromDefIndex");
 	MarkNativeAsOptional("PTaH_MD5File");
 	MarkNativeAsOptional("PTaH_GetAddrInfo");
 	MarkNativeAsOptional("PTaH_Gai_StrError");

--- a/PTaH.inc
+++ b/PTaH.inc
@@ -222,7 +222,8 @@ methodmap CEconItemView
 	*/
 	public bool IsCustomItemView() 
     { 
-		return this.GetAccountID() != 0;
+		int iBuf = this.GetAccountID();
+		return iBuf != 0 && iBuf != 1;
     }
 	
 	/**

--- a/PTaH.inc (ru)
+++ b/PTaH.inc (ru)
@@ -112,15 +112,6 @@ methodmap CEconItemDefinition
 	 * @error CEconItemDefinition == NULL.
 	*/
 	public native int GetClassName(char[] sBuf, int iLen);
-	
-	/**
-	 *	Получает CCSWeaponData.
-	 *	-
-	 * @return	Возвращает CCSWeaponData.
-	 *	-
-	 * @error CEconItemDefinition == NULL.
-	*/
-	public native Address GetCCSWeaponData();
 };
 
 methodmap CEconItemView
@@ -231,7 +222,7 @@ methodmap CEconItemView
 	*/
 	public bool IsCustomItemView() 
     { 
-		return this.GetAccountID() != 0 ? true:false;
+		return this.GetAccountID() != 0;
     }
 	
 	/**
@@ -288,13 +279,13 @@ methodmap CEconItemView
 	 *	-
 	 * @error CEconItemView == NULL.
 	*/
-	//public native int GetStatTrakKill(); - удалено Valve 17.8.2017
+	public native int GetStatTrakKill();
 };
 
 methodmap AddrInfo
 {
-	//!!!!!!!!!!!!!!!!!!!!! AddrInfo is not Handle, CloseHandle() - NOT NEEDED !!!!!!!!!!!!!!!!!!!!!
-	//!!!!!!!!!!!!!!!!!!!!! Always check, if not wounded AddrInfo - NULL ( if(AddrInfo) ) !!!!!!!!!!!!!!!!!!!!!
+	//!!!!!!!!!!!!!!!!!!!!! AddrInfo не является Handle, CloseHandle() - НЕ НУЖЕН !!!!!!!!!!!!!!!!!!!!!
+	//!!!!!!!!!!!!!!!!!!!!! Всегда проверяйте, не равен ли AddrInfo - NULL ( if(AddrInfo) ) !!!!!!!!!!!!!!!!!!!!!
 	
 	/**
 	 *	Получает версию IP адреса (AF_INET или AF_INET6).
@@ -449,7 +440,7 @@ typeset PTaHCB
 	*/
 	function Action (const char[] sName, char sPassword[128], const char[] sIp, const char[] sSteamID, char rejectReason[512]);
 	
-	/** ServerConsolePrint
+	/** ServerConsolePrint (Сообщения, которые находятся в другом потоке, игнорируются)
 	 *
 	 *	Вызывается перед выводом сообщение в консоль сервера (Будьте аккуратны при роботе с сообщениями).
 	 *	-
@@ -460,6 +451,15 @@ typeset PTaHCB
 	*/
 	function Action (const char[] sMessage, LoggingSeverity severity);
 };
+
+/**
+ *	Версия PTaH.
+ * @param sBuffer				Строка куда будет записана версия (указывать не обязательно, только если нужно получить версию в виде строки).
+ * @param len					Длина строки.
+ *	-
+ * @return	Возвращает версию PTaH (например 108, sBuffer = "1.0.8").
+*/
+native int PTaH_Version(char[] sBuf = NULL_STRING, int iLen = 0);
 
 /**
  *	Активирует хук.
@@ -522,16 +522,6 @@ native CEconItemView PTaH_GetEconItemViewFromWeapon(int iEnt);
 native int PTaH_GivePlayerItem(int iClient, const char[] sClassname, CEconItemView Item);
 
 /**
- *	Спавнит предмет по DefinitionIndex (CEconItemView валидный, так что оружие не имеет багов).
- * @param DefIndex				DefinitionIndex предмета.
- * @param origin				origin, или NULL_VECTOR.
- * @param angles				angles, или NULL_VECTOR.
- *	-
- * @return	Возвращает индекс предмета.
-*/
-native int PTaH_SpawnItemFromDefIndex(int DefIndex, const float origin[3] = NULL_VECTOR, const float angles[3] = NULL_VECTOR);
-
-/**
  *	Получает md5 hash файла.
  * @param sFile					Путь к файлу.
  * @param sBuffer				Строка куда будет записан hash.
@@ -582,6 +572,7 @@ public Extension __ext_PTaH =
 #if !defined REQUIRE_EXTENSIONS
 public __ext_PTaH_SetNTVOptional()
 {
+	MarkNativeAsOptional("PTaH_Version");
 	MarkNativeAsOptional("PTaH");
 	MarkNativeAsOptional("PTaH_GetItemDefinitionByName");
 	MarkNativeAsOptional("PTaH_GetItemDefinitionByDefIndex");
@@ -589,7 +580,6 @@ public __ext_PTaH_SetNTVOptional()
 	MarkNativeAsOptional("CEconItemDefinition.GetLoadoutSlot");
 	MarkNativeAsOptional("CEconItemDefinition.GetNumSupportedStickerSlots");
 	MarkNativeAsOptional("CEconItemDefinition.GetClassName");
-	MarkNativeAsOptional("CEconItemDefinition.GetCCSWeaponData");
 	MarkNativeAsOptional("PTaH_GetItemInLoadout");
 	MarkNativeAsOptional("PTaH_GetEconItemViewFromWeapon");
 	MarkNativeAsOptional("CEconItemView.GetCustomPaintKitIndex");
@@ -607,7 +597,6 @@ public __ext_PTaH_SetNTVOptional()
 	MarkNativeAsOptional("CEconItemView.GetCustomName");
 	MarkNativeAsOptional("CEconItemView.GetStatTrakKill");
 	MarkNativeAsOptional("PTaH_GivePlayerItem");
-	MarkNativeAsOptional("PTaH_SpawnItemFromDefIndex");
 	MarkNativeAsOptional("PTaH_MD5File");
 	MarkNativeAsOptional("PTaH_GetAddrInfo");
 	MarkNativeAsOptional("PTaH_Gai_StrError");

--- a/PTaH.inc (ru)
+++ b/PTaH.inc (ru)
@@ -222,7 +222,8 @@ methodmap CEconItemView
 	*/
 	public bool IsCustomItemView() 
     { 
-		return this.GetAccountID() != 0;
+		int iBuf = this.GetAccountID();
+		return iBuf != 0 && iBuf != 1;
     }
 	
 	/**

--- a/forwards.cpp
+++ b/forwards.cpp
@@ -32,7 +32,7 @@
 #include "extension.h"
 #include "forwards.h"
 #include "classes.h"
-#include <tier0/dbg.h> 
+#include "tier0/dbg.h"
 
 CForwardManager g_pPTaHForwards;
 
@@ -101,7 +101,8 @@ DETOUR_DECL_MEMBER1(ExecuteStringCommand, bool, const char *, szMsg)
 
 DETOUR_DECL_MEMBER4(LoggingSeverity, LoggingResponse_t, LoggingChannelID_t, channelID, LoggingSeverity_t, severity, Color, color, const tchar *, pMessage)
 {
-	if(pMessage != NULL && g_pPTaHForwards.m_pServerConsolePrint->GetFunctionCount() > 0)
+	//Thread_Id == ke::GetCurrentThreadId() - Temporary solution to avoid crashes
+	if(pMessage != NULL && g_pPTaHForwards.m_pServerConsolePrint->GetFunctionCount() > 0 && g_pPTaHForwards.Thread_Id == ke::GetCurrentThreadId())
 	{
 		cell_t res = PLUGIN_CONTINUE;
 		g_pPTaHForwards.m_pServerConsolePrint->PushString(pMessage);
@@ -165,6 +166,8 @@ size_t UTIL_StringToSignature(const char *str, char buffer[], size_t maxlength)
 
 bool CForwardManager::Init()
 {
+	Thread_Id = ke::GetCurrentThreadId();
+	
 	int offset = -1;
 	
 	if(!g_pGameConf[GameConf_SDKT]->GetOffset("GiveNamedItem", &offset))
@@ -270,7 +273,6 @@ bool CForwardManager::Init()
 		return false;
 	}
 	else m_pLoggingSeverity->EnableDetour();
-	
 	
 	
 	

--- a/forwards.h
+++ b/forwards.h
@@ -34,6 +34,7 @@
 
 #include "extension.h"
 #include "netmessages.pb.h"
+#include <amtl/am-thread-utils.h> 
 
 template <int Type, class NetMessage, int Group, bool reliable>
 class CNetMessagePB : public INetMessage, public NetMessage {
@@ -88,6 +89,8 @@ public:
 	IChangeableForward *m_pMapContentList;
 	CDetour *m_pLoggingSeverity;
 	IChangeableForward *m_pServerConsolePrint;
+	
+	ke::ThreadId Thread_Id;
 };
 
 extern CForwardManager g_pPTaHForwards;

--- a/smsdk_config.h
+++ b/smsdk_config.h
@@ -40,7 +40,8 @@
 /* Basic information exposed publicly */
 #define SMEXT_CONF_NAME			"PTaH (P Tools and Hooks)"
 #define SMEXT_CONF_DESCRIPTION	"Expanding sdkhooks and sdktools"
-#define SMEXT_CONF_VERSION		"1.0.7"
+#define SMEXT_CONF_VERSION		"1.0.8"
+#define PTaH_VERSION			108
 #define SMEXT_CONF_AUTHOR		"Phoenix (˙·٠●Феникс●٠·˙)"
 #define SMEXT_CONF_URL			"https://zizt.ru/ | http://hlmod.ru | https://forums.alliedmods.net/"
 #define SMEXT_CONF_LOGTAG		"PTaH"


### PR DESCRIPTION
Add
PTaH_Version - Allows you to check the current version of PTaH

Restored
GetStatTrakKill - Thank you Kailo

Removed
PTaH_SpawnItemFromDefIndex - This function is no longer needed, since the weapon created with the CreateEntityByName function is working fine
GetCCSWeaponData - are not used anywhere

Fix
GetDefinitionIndex - fixed a bug that always returned 0