### PR TITLE
Updated msvcbuild scripts

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -337,6 +337,8 @@ class ExtensionConfig(object):
 
     if compiler.like('msvc'):
       compiler.defines += ['COMPILER_MSVC', 'COMPILER_MSVC32']
+      if compiler.version >= 1900:
+        compiler.linkflags += ['legacy_stdio_definitions.lib']
     else:
       compiler.defines += ['COMPILER_GCC']
 

--- a/AMBuilder
+++ b/AMBuilder
@@ -59,6 +59,8 @@ for sdk_name in ['csgo']:
     vs_year = ''
     if msvc_ver == 1800:
       vs_year = '2013'
+    elif 1900 <= msvc_ver < 2000:
+      vs_year = '2015'
     else:
       raise Exception('Cannot find libprotobuf for MSVC version "' + str(compiler.version) + '"')
 


### PR DESCRIPTION
Not sure which version of sm/mm or version of msvc ptah was compiled against for windows, but this updates scripts for recent years of msvc.

Compiled with msvc 2017, SM 1.9, and MM:S 1.10, and extension no longer causes server crashes running SM 1.10. This should fix #5 