### PR TITLE
Update AmBuilder (To work on SM 1.10)

### DIFF
--- a/AMBuilder
+++ b/AMBuilder
@@ -8,7 +8,13 @@ sourceFiles = [
   'extension.cpp',
   'forwards.cpp',
   'natives.cpp',
-  'classes.cpp'
+  'classes.cpp',
+  '../public/libudis86/decode.c',
+  '../public/libudis86/udis86.c',
+  '../public/libudis86/itab.c',
+  '../public/libudis86/syn-att.c',
+  '../public/libudis86/syn-intel.c',
+  '../public/libudis86/syn.c'
 ]
 
 ###############


### PR DESCRIPTION
If there is an error at compilation then add
(public/libudis86/udis86.c)

#include "string.h"