### PR TITLE
1.1.2

### DIFF
--- a/PTaH.games.txt
+++ b/PTaH.games.txt
@@ -23,171 +23,196 @@
 			//CEconItemDefinition::GetLoadoutSlot() - does not work, always returns 0
 			"GetLoadoutSlot"
 			{
-				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x8B\x45\x08\x8D\x50\xFF"
-				"linux"			"\x55\x89\xE5\x8B\x45\x0C\x8B\x55\x08\x8D\x48\xFF"
+				"library"       "server"
+				"windows"       "\x55\x8B\xEC\x8B\x45\x08\x8D\x50\xFF"
+				"linux"         "\x55\x89\xE5\x8B\x45\x0C\x8B\x55\x08\x8D\x48\xFF"
 			}
 			"FindMatchingWeaponsForTeamLoadout"
 			{
-				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x83\xEC\x08\x53\x56\x57\x89\x4D\xF8"
-				"linux"			"\x55\x89\xE5\x57\x56\x53\x83\xEC\x3C\x0F\xB6\x4D\x14"
+				"library"       "server"
+				"windows"       "\x55\x8B\xEC\x83\xEC\x08\x53\x56\x57\x89\x4D\xF8"
+				"linux"         "\x55\x89\xE5\x57\x56\x53\x83\xEC\x3C\x0F\xB6\x4D\x14"
 			}
 			"SpawnItem"
 			{
-				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x51\x53\x56\x57\xE8\x2A\x2A\x2A\x2A\x8B\x5D\x08"
-				"linux"			"\x55\x89\xE5\x57\x56\x53\x83\xEC\x4C\x8B\x55\x08\x8B\x7D\x0C\x8B\x5D\x20"
+				"library"       "server"
+				"windows"       "\x55\x8B\xEC\x51\x53\x56\x57\xE8\x2A\x2A\x2A\x2A\x8B\x5D\x08"
+				"linux"         "\x55\x89\xE5\x57\x56\x53\x83\xEC\x4C\x8B\x55\x08\x8B\x7D\x0C\x8B\x5D\x20"
 			}
 			"FX_FireBullets"
 			{
-				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x83\xE4\xF8\x81\xEC\x40\x02\x00\x00"
-				"linux"			"\x55\x89\xE5\x57\x56\x53\x81\xEC\x9C\x02\x00\x00\x8B\x5D\x10"
+				"library"       "server"
+				"windows"       "\x55\x8B\xEC\x83\xE4\xF8\x81\xEC\x40\x02\x00\x00"
+				"linux"         "\x55\x89\xE5\x57\x56\x53\x81\xEC\x9C\x02\x00\x00\x8B\x5D\x10"
 			}
 			"g_CPlayerVoiceListener"
 			{
-				"library"		"server"
-				"windows"		"\x6A\x00\xB9\x2A\x2A\x2A\x2A\xE8\x2A\x2A\x2A\x2A\x6A\x40"
-				"linux"			"\x55\x89\xE5\x83\xEC\x28\xC6\x05\x2A\x2A\x2A\x2A\x00\xC6\x05\x2A\x2A\x2A\x2A\x00\xC6\x05\x2A\x2A\x2A\x2A\x00\xC6\x05\x2A\x2A\x2A\x2A\x00\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x44\x24\x0C\x00\x40\x00\x00"
+				"library"       "server"
+				"windows"       "\x6A\x00\xB9\x2A\x2A\x2A\x2A\xE8\x2A\x2A\x2A\x2A\x6A\x40"
+				"linux"         "\x55\x89\xE5\x83\xEC\x28\xC6\x05\x2A\x2A\x2A\x2A\x00\xC6\x05\x2A\x2A\x2A\x2A\x00\xC6\x05\x2A\x2A\x2A\x2A\x00\xC6\x05\x2A\x2A\x2A\x2A\x00\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\x00\x00\x00\x00\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x05\x2A\x2A\x2A\x2A\xFF\xFF\x7F\x7F\xC7\x44\x24\x0C\x00\x40\x00\x00"
 			}
 		}
 		"Offsets"
 		{
 			"ConnectClient"
 			{
-				"windows"		"54"
-				"linux"			"55"
+				"windows"       "54"
+				"linux"         "55"
 			}
 			"RejectConnection"
 			{
-				"windows"		"52"
-				"linux"			"53"
+				"windows"       "52"
+				"linux"         "53"
 			}
 			"GetItemDefinitionByDefIndex"
 			{
-				"windows"		"208"
-				"linux"			"208"
+				"windows"       "208"
+				"linux"         "208"
 			}
 			"GetAttributeDefinitionInterface"
 			{
-				"windows"		"27"
-				"linux"			"27"
+				"windows"       "27"
+				"linux"         "27"
 			}
 			"GetDefinitionIndex"
 			{
-				"windows"		"0"
-				"linux"			"0"
+				"windows"       "0"
+				"linux"         "0"
 			}
 			"GetNumSupportedStickerSlots"
 			{
-				"windows"		"44"
-				"linux"			"45"
+				"windows"       "44"
+				"linux"         "45"
+			}
+			"GetEconImage"
+			{
+				"windows"       "108"
+				"linux"         "108"
+			}
+			"GetViewModel"
+			{
+				"windows"       "148"
+				"linux"         "148"
+			}
+			"GetWorldModel"
+			{
+				"windows"       "156"
+				"linux"         "156"
+			}
+			"GetDroppedModel"
+			{
+				"windows"       "160"
+				"linux"         "160"
 			}
 			"GetClassName"
 			{
-				"windows"		"444"
-				"linux"			"444"
+				"windows"       "444"
+				"linux"         "444"
 			}
 			"GetCustomPaintKitIndex"
 			{
-				"windows"		"1"
-				"linux"			"2"
+				"windows"       "1"
+				"linux"         "2"
 			}
 			"GetCustomPaintKitSeed"
 			{
-				"windows"		"2"
-				"linux"			"3"
+				"windows"       "2"
+				"linux"         "3"
 			}
 			"GetCustomPaintKitWear"
 			{
-				"windows"		"3"
-				"linux"			"4"
+				"windows"       "3"
+				"linux"         "4"
 			}
 			"GetStickerAttributeBySlotIndexFloat"
 			{
-				"windows"		"4"
-				"linux"			"5"
+				"windows"       "4"
+				"linux"         "5"
 			}
 			"GetStickerAttributeBySlotIndexInt"
 			{
-				"windows"		"5"
-				"linux"			"6"
+				"windows"       "5"
+				"linux"         "6"
 			}
 			"IsTradable"
 			{
-				"windows"		"6"
-				"linux"			"7"
+				"windows"       "6"
+				"linux"         "7"
 			}
 			"IsMarketable"
 			{
-				"windows"		"7"
-				"linux"			"8"
+				"windows"       "7"
+				"linux"         "8"
 			}
 			"GetItemDefinition"
 			{
-				"windows"		"12"
-				"linux"			"13"
+				"windows"       "12"
+				"linux"         "13"
 			}
 			"GetAccountID"
 			{
-				"windows"		"13"
-				"linux"			"14"
+				"windows"       "13"
+				"linux"         "14"
+			}
+			"GetItemID"
+			{
+				"windows"       "14"
+				"linux"         "15"
 			}
 			"GetQuality"
 			{
-				"windows"		"15"
-				"linux"			"16"
+				"windows"       "15"
+				"linux"         "16"
 			}
 			"GetRarity"
 			{
-				"windows"		"16"
-				"linux"			"17"
+				"windows"       "16"
+				"linux"         "17"
 			}
 			"GetFlags"
 			{
-				"windows"		"17"
-				"linux"			"18"
+				"windows"       "17"
+				"linux"         "18"
 			}
 			"GetOrigin"
 			{
-				"windows"		"18"
-				"linux"			"19"
+				"windows"       "18"
+				"linux"         "19"
 			}
 			"GetCustomName"
 			{
-				"windows"		"22"
-				"linux"			"23"
+				"windows"       "22"
+				"linux"         "23"
 			}
 			"IterateAttributes"
 			{
-				"windows"		"25"
-				"linux"			"26"
+				"windows"       "25"
+				"linux"         "26"
 			}
 			"UpdateAcknowledgedFramecount"
 			{
-				"windows"		"17"
-				"linux"			"55"
+				"windows"       "17"
+				"linux"         "55"
 			}
 			"ExecuteStringCommand"
 			{
-				"windows"		"30"
-				"linux"			"25"
+				"windows"       "30"
+				"linux"         "25"
 			}
 			"ClientPrintf"
 			{
-				"windows"		"32"
-				"linux"			"27"
+				"windows"       "32"
+				"linux"         "27"
 			}
 			"SendInventoryUpdateEvent"
 			{
-				"windows"		"16"
-				"linux"			"17"
+				"windows"       "16"
+				"linux"         "17"
 			}
 			"InventoryItems"
 			{
-				"windows"		"44"
-				"linux"			"44"
+				"windows"       "44"
+				"linux"         "44"
 			}
 		}
 	}

--- a/PTaH.games.txt
+++ b/PTaH.games.txt
@@ -179,6 +179,16 @@
 				"windows"		"32"
 				"linux"			"27"
 			}
+			"SendInventoryUpdateEvent"
+			{
+				"windows"		"16"
+				"linux"			"17"
+			}
+			"InventoryItems"
+			{
+				"windows"		"44"
+				"linux"			"44"
+			}
 		}
 	}
 }

--- a/PTaH.inc
+++ b/PTaH.inc
@@ -7,7 +7,7 @@
 
 enum PTaH_HookType
 {
-	UnHook,
+	UnHook = 0,
 	Hook
 };
 
@@ -27,14 +27,95 @@ enum PTaH_HookEvent
 	PTaH_ExecuteStringCommandPost,
 	PTaH_ClientConnectPre,
 	PTaH_ClientConnectPost,
+	PTaH_InventoryUpdatePost = 25
 };
 
 enum EStickerAttributeType 
-{ 
-    StickerID,
-    WearProgress,
-    PatternScale,
-    PatternRotation 
+{
+	StickerID = 0,        // int
+	WearProgress,         // float
+	PatternScale,         // float
+	PatternRotation       // float
+};
+
+enum EEconItemQuality
+{
+	AE_UNDEFINED = -1,
+
+	AE_NORMAL = 0,
+	AE_GENUINE = 1,
+	AE_VINTAGE,	
+	AE_UNUSUAL,
+	AE_UNIQUE,
+	AE_COMMUNITY,
+	AE_DEVELOPER,
+	AE_SELFMADE,
+	AE_CUSTOMIZED,
+	AE_STRANGE,
+	AE_COMPLETED,
+	AE_HAUNTED,
+	AE_TOURNAMENT,
+	AE_FAVORED,
+
+	AE_MAX_TYPES,
+};
+
+enum eEconItemFlags
+{
+	kEconItemFlag_CannotTrade				= 1 << 0,
+	kEconItemFlag_CannotBeUsedInCrafting	= 1 << 1,
+	kEconItemFlag_CanBeTradedByFreeAccounts	= 1 << 2,
+	kEconItemFlag_NonEconomy				= 1 << 3,		// used for items that are meant to not interact in the economy -- these can't be traded, gift-wrapped, crafted, etc.
+	// combination of the above flags used in code
+	kEconItemFlags_CheckFlags_CannotTrade			= kEconItemFlag_CannotTrade,
+	kEconItemFlags_CheckFlags_NotUsableInCrafting	= kEconItemFlag_CannotBeUsedInCrafting,
+
+	kEconItemFlags_CheckFlags_AllGCFlags			= kEconItemFlags_CheckFlags_CannotTrade | kEconItemFlags_CheckFlags_NotUsableInCrafting,
+};
+
+enum eEconItemRarity
+{
+	kEconItemRarity_Default = 0,
+	kEconItemRarity_Common,
+	kEconItemRarity_Uncommon,
+	kEconItemRarity_Rare,
+	kEconItemRarity_Mythical,
+	kEconItemRarity_Legendary,
+	kEconItemRarity_Ancient,
+	kEconItemRarity_Immortal
+};
+
+enum eEconItemOrigin
+{
+	kEconItemOrigin_Invalid = -1,
+
+	kEconItemOrigin_Drop = 0,
+	kEconItemOrigin_Achievement,
+	kEconItemOrigin_Purchased,
+	kEconItemOrigin_Traded,
+	kEconItemOrigin_Crafted,
+	kEconItemOrigin_StorePromotion,
+	kEconItemOrigin_Gifted,
+	kEconItemOrigin_SupportGranted,
+	kEconItemOrigin_FoundInCrate,
+	kEconItemOrigin_Earned,
+	kEconItemOrigin_ThirdPartyPromotion,
+	kEconItemOrigin_GiftWrapped,
+	kEconItemOrigin_HalloweenDrop,
+	kEconItemOrigin_PackageItem,
+	kEconItemOrigin_Foreign,
+	kEconItemOrigin_CDKey,
+	kEconItemOrigin_CollectionReward,
+	kEconItemOrigin_PreviewItem,
+	kEconItemOrigin_SteamWorkshopContribution,
+	kEconItemOrigin_PeriodicScoreReward,
+	kEconItemOrigin_Recycling,
+	kEconItemOrigin_TournamentDrop,
+	kEconItemOrigin_StockItem,
+	KEconItemOrigin_QuestReward,
+	KEconItemOrigin_LevelUpReward,
+
+	kEconItemOrigin_Max,
 };
 
 enum CEconItemDefinition
@@ -47,220 +128,286 @@ enum CEconItemView
 	CEconItemView_NULL = 0
 };
 
+enum CCSPlayerInventory
+{
+	CCSPlayerInventory_NULL = 0
+};
+
 
 
 methodmap CEconItemDefinition
 {
-	//!!!!!!!!!!!!!!!!!!!!! CEconItemDefinition is not Handle, CloseHandle() - NOT NEEDED !!!!!!!!!!!!!!!!!!!!!
-	//!!!!!!!!!!!!!!!!!!!!! Always check, if not wounded CEconItemDefinition - NULL ( if(ItemDefinition) ) !!!!!!!!!!!!!!!!!!!!!
+	// CEconItemDefinition is not Handle, CloseHandle() - NOT NEEDED !!!!!!!!!!!!!!!!!!!!!
+	// Always check, if not wounded CEconItemDefinition - NULL ( if(ItemDefinition) ) !!!!!!!!!!!!!!!!!!!!!
 
 	/**
-	 *	Gets DefinitionIndex.
-	 *	-
-	 * @return	Returns DefinitionIndex.
-	 *	-
-	 * @error CEconItemDefinition == NULL.
-	*/
+	 * Gets DefinitionIndex.
+	 *
+	 * @return             Returns definition index.
+	 *
+	 * @error              CEconItemDefinition == NULL.
+	 */
 	public native int GetDefinitionIndex();
-	
+
 	/**
-	 *	Gets LoadoutSlot.
-	 * @param iTeam		Index Commands.
-	 *	-
-	 * @return	Returns LoadoutSlot.
-	 *	-
-	 * @error CEconItemDefinition == NULL.
-	*/
+	 * Gets LoadoutSlot.
+	 *
+	 * @param iTeam        Team index or -1 if independently.
+	 *
+	 * @return             Returns loadout slot index.
+	 *
+	 * @error              CEconItemDefinition == NULL.
+	 */
 	public native int GetLoadoutSlot(int iTeam = -1);
-	
+
 	/**
-	 *	Gets the amount slots for Sticker.
-	 *	-
-	 * @return	Returns StickerSlotsCount.
-	 *	-
-	 * @error CEconItemDefinition == NULL.
-	*/
+	 * Gets the amount slot for stickers.
+	 *
+	 * @return             Returns sticker slot count.
+	 *
+	 * @error              CEconItemDefinition == NULL.
+	 */
 	public native int GetNumSupportedStickerSlots();
-	
+
 	/**
-	 *	Gets ClassName.
-	 * @param sBuf			line.
-	 * @param iLen			row size.
-	 *	-
-	 * @return	Returns length ClassName.
-	 *	-
-	 * @error CEconItemDefinition == NULL.
-	*/
-	public native int GetClassName(char[] sBuf, int iLen);
+	 * Gets item classname.
+	 *
+	 * @param sBuffer      Destination string buffer.
+	 * @param iLen         Maximum length of output string buffer.
+	 *
+	 * @return             Returns classname length.
+	 *
+	 * @error              CEconItemDefinition == NULL.
+	 */
+	public native int GetClassName(char[] sBuffer, int iLen);
 };
 
 methodmap CEconItemView
 {
-	//!!!!!!!!!!!!!!!!!!!!! CEconItemView is not Handle, CloseHandle() - NOT NEEDED !!!!!!!!!!!!!!!!!!!!!
-	//!!!!!!!!!!!!!!!!!!!!! Always check, if not wounded CEconItemDefinition - NULL ( if(ItemDefinition) ) !!!!!!!!!!!!!!!!!!!!!
-	//!!!!!!!!!!!!!!!!!!!!! If a player will left from a server after function call to obtain CEconItemView (PTaH_GetEconItemViewFromWeapon this applies if iEnt will be destroyed) You get crash server!!!!!!!!!!!!!!!!!!!!!
+	// CEconItemView is not Handle, CloseHandle() - NOT NEEDED !!!!!!!!!!!!!!!!!!!!!
+	// Always check, if not wounded CEconItemDefinition - NULL ( if(ItemDefinition) ) !!!!!!!!!!!!!!!!!!!!!
+	// If a player will left from a server after function call to obtain CEconItemView (PTaH_GetEconItemViewFromEconEntity this applies if iEntity will be destroyed). You get crash server!!!!!!!!!!!!!!!!!!!!!
 	
 	/**
-	 *	Gets the index of the skin weapons.
-	 *	-
-	 * @return	Returns PaintKitIndex.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
+	 * Gets the index of skin.
+	 *
+	 * @return             Returns PaintKit index.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
 	public native int GetCustomPaintKitIndex();
-	
+
 	/**
-	 *	Gets displacement of weapon skins.
-	 *	-
-	 * @return	Returns PaintKitSeed.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
+	 * Gets displacement of skin.
+	 *
+	 * @return             Returns PaintKit seed.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
 	public native int GetCustomPaintKitSeed();
-	
+
 	/**
-	 *	Gets quality skins weapons.
-	 * @param def			default value.
-	 *	-
-	 * @return	Returns PaintKitWear.
-	 *	-
+	 * Gets quality of skins.
+	 *
+	 * @param fDef         Default value if PaintKit is not found.
+	 *
+	 * @return             Returns PaintKit wear.
+	 *
 	 * @error CEconItemView == NULL.
-	*/
-	public native float GetCustomPaintKitWear(float def = -1.0);
-	
+	 */
+	public native float GetCustomPaintKitWear(float flDef = -1.0);
+
 	/**
-	 *	Get the value of an attribute by number slots Sticker.
-	 * @param iSlot			Index Slot.
-	 * @param ESAT			attribute.
-	 * @param def			default value.
-	 *	-
-	 * @return	Returns StickerAttribute.
-	 *	-
-	 * @error CEconItemView == NULL.
-	 * -
-	 * StickerID - returns int, def also need to transmit int
-	 * WearProgress, PatternScale, PatternRotation - returns float, def also need to transmit float
-	*/
-	public native any GetStickerAttributeBySlotIndex(int iSlot, EStickerAttributeType ESAT, any def);
-	
+	 * Get sticker index by slot.
+	 *
+	 * @param iSlot	       Sticker slot index.
+	 * @param ESAT         Sticker attribute type.
+	 * @param Def          Default value if sticker is not found.
+	 *
+	 * @return             Returns attribute value.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
+	public native any GetStickerAttributeBySlotIndex(int iSlot, EStickerAttributeType ESAT, any Def = 0);
+
 	/**
-	 *	Check: Is it possible to exchange weapons
-	 *	-
-	 * @return	Returns Tradable.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
+	 * Gets is it possible to exchange weapons.
+	 *
+	 * @return             Returns is tradable.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
 	public native bool IsTradable();
-	
+
 	/**
-	 *	Check: Is it possible to sell weapons - http://steamcommunity.com/market/
-	 *	-
-	 * @return	Returns Marketable.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
+	 * Gets is it possible to sell weapons on http://steamcommunity.com/market/.
+	 *
+	 * @return             Returns Marketable.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
 	public native bool IsMarketable();
-	
+
 	/**
-	 *	Gets ItemDefinition.
-	 *	-
-	 * @return	Returns CEconItemDefinition.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
+	 * Gets CEconItemDefinition.
+	 *
+	 * @return             Returns pointer in CEconItemDefinition.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
 	public native CEconItemDefinition GetItemDefinition();
-	
+
 	/**
-	 *	Gets AccountID Owner skin (You can verify by GetSteamAccountID).
-	 *	-
-	 * @return	Returns AccountID.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
+	 * Gets AccountID owner of ItemView.
+	 *
+	 * @return             Returns AccountID.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
 	public native int GetAccountID();
-	
+
 	/**
-	 *	Gets Index Owner weapons.
-	 *	-
-	 * @return	Returns iClient.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
+	 * Gets owner of ItemView.
+	 *
+	 * @return             Returns client index or -1 is not found.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
 	public int GetClientIndex() 
 	{ 
-		int AccountID = this.GetAccountID();
-		for (int i = 1; i <= MaxClients; i++) if(IsClientInGame(i) && AccountID == GetSteamAccountID(i)) return i;
+		int iAccountID = this.GetAccountID();
+		
+		for(int i = MaxClients + 1; --i;)
+		{
+			if(IsClientAuthorized(i) && iAccountID == GetSteamAccountID(i))
+			{
+				return i;
+			}
+		}
+
 		return -1;
 	}
-	
+
 	/**
-	 *	Gets Custom ItemView.
-	 *	-
-	 * @return	Returns IsCustom.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
+	 * Gets is custom of ItemView.
+	 *
+	 * @return             Returns is custom.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
 	public bool IsCustomItemView() 
-	{ 
-		int iBuf = this.GetAccountID();
-		return iBuf != 0 && iBuf != 1;
+	{
+		int iAccountID = this.GetAccountID();
+
+		return iAccountID != 0 && iAccountID != -1;
 	}
-	
+
 	/**
-	 *	Gets Quality skins.
-	 *	-
-	 * @return	Returns Quality.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
-	public native int GetQuality();
-	
+	 * Gets EconItem quality.
+	 *
+	 * @return             Returns quality.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
+	public native EEconItemQuality GetQuality();
+
 	/**
-	 *	Gets Rarity skins.
-	 *	-
-	 * @return	Returns Rarity.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
-	public native int GetRarity();
-	
+	 * Gets EconItem rarity.
+	 *
+	 * @return             Returns rarity.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
+	public native eEconItemRarity GetRarity();
+
 	/**
-	 *	Gets Flags skins.
-	 *	-
-	 * @return	Returns Flags.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
-	public native int GetFlags();
-	
+	 *	Gets EconItem flags.
+	 *
+	 * @return             Returns flags.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
+	public native eEconItemFlags GetFlags();
+
 	/**
-	 *	Gets Origin skins.
-	 *	-
-	 * @return	Returns Origin.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
-	public native int GetOrigin();
-	
+	 * Gets EconItem origin.
+	 *
+	 * @return             Returns origin.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
+	public native eEconItemOrigin GetOrigin();
+
 	/**
-	 *	Gets Name-tag skins.
-	 * @param sBuf			line.
-	 * @param iLen			row size (maximum length, which can be - 161).
-	 *	-
-	 * @return	Returns length name-tag.
-	 *	-
-	 * @error CEconItemView == NULL.
-	*/
-	public native int GetCustomName(char[] sBuf, int iLen);
-	
+	 * Gets nametag on skin.
+	 *
+	 * @param sBuffer      Destination string buffer.
+	 * @param iLen         Maximum length of output string buffer..
+	 *
+	 * @return             Returns nametag length.
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
+	public native int GetCustomName(char[] sBuffer, int iLen);
+
 	/**
-	 *	Gets amount StatTrak.
-	 *	-
-	 * @return	Returns amount StatTrak (if StatTrak = -1 therefore it is not).
-	 *	-
-	 * @error CEconItemView == NULL.
+	 * Gets amount StatTrak.
+	 *
+	 * @return             Returns amount StatTrak. If -1, StatTrak attribute is not found.
+	 *
+	 * @error              CEconItemView == NULL.
 	*/
 	public native int GetStatTrakKill();
+
+	/**
+	 * Gets attribute value by index.
+	 *
+	 * @param iAttribIndex  Attribute definition index.
+	 * @param Value         Variable to store value.
+	 *
+	 * @return              Returns is attribute exist.
+	 *
+	 * @error               CEconItemView == NULL or iAttribIndex invalid.
+	 */
+	public native bool GetAttributeValueByIndex(int iAttribIndex, any &Value);
+};
+
+methodmap CCSPlayerInventory
+{
+	// CCSPlayerInventory is not Handle, CloseHandle() - NOT NEEDED !!!!!!!!!!!!!!!!!!!!!
+	// Always check, if not wounded CCSPlayerInventory - NULL ( if(PlayerInventory) ) !!!!!!!!!!!!!!!!!!!!!
+
+	/**
+	 * Gets CEconItemView in LoadoutSlot.
+	 *
+	 * @param iTeamIndex    Team index.
+	 * @param iLoadoutSlot  Loadout slot index.
+	 *
+	 * @return              Returns pointer in CEconItemView.
+	 *
+	 * @error               CCSPlayerInventory == NULL or team index is invalid.
+	 */
+	public native CEconItemView GetItemInLoadout(int iTeam, int iLoadoutSlot);
+
+	/**
+	 * Gets custom items count in inventory.
+	 *
+	 * @return              Returns items count.
+	 *
+	 * @error               CCSPlayerInventory == NULL.
+	 */
+	public native int GetItemsCount();
+
+	/**
+	 * Gets CEconItemView in inventory by index.
+	 *
+	 * @param iPos          Item position in inventor.
+	 *
+	 * @return              Returns pointer in CEconItemView.
+	 *
+	 * @error               CCSPlayerInventory == NULL.
+	 */
+	public native CEconItemView GetItem(int iPos);
 };
 
 
@@ -269,292 +416,335 @@ typeset PTaHCB
 {
 	/** GiveNamedItemPre
 	 *
-	 *	Called before the issuance of the item.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param sClassname		Classname weapons.
-	 * @param Item				Customization item.
-	 * @param IgnoredCEconItemView	If true ignores CEconItemView the item.
-	 * @param OriginIsNULL		True if Origin is NULL_VECTOR.
-	 * @param Origin			Coordinates where the item was created at (You cannot compare Origin == NULL_VECTOR or set Origin = NULL_VECTOR, use OriginIsNULL param for it).
-	 *	-
-	 * @return	Return Plugin_Stop or Plugin_Handled stop granting item. Return Plugin_Continue allow issuance item without changes. Return Plugin_Changed allow issuance item with changes.
-	*/
-	function Action (int iClient, char sClassname[64], CEconItemView &Item, bool &IgnoredCEconItemView, bool &OriginIsNULL, float Origin[3]);
-	
+	 * Called before the issuance of the item.
+	 *
+	 * @param iClient       Client index.
+	 * @param sClassname    Weapon classname.
+	 * @param pItemView     Customization item.
+	 * @param bIgnoredView  Is ignores CEconItemView the item.
+	 * @param bOriginNULL   Origin is unspecified.
+	 * @param vecOrigin     Coordinates where the item was created.
+	 *                      You cannot compare vecOrigin == NULL_VECTOR, use bOriginNULL param for it.
+	 *
+	 * @return              Return Plugin_Stop or Plugin_Handled for stop granting item.
+	 *                      Return Plugin_Continue for allow issuance item without changes.
+	 *                      Return Plugin_Changed for allow issuance item with changes.
+	 */
+	function Action (int iClient, char sClassname[64], CEconItemView &bItemView, bool &bIgnoredView, bool &bOriginNULL, float vecOrigin[3]);
+
 	/** GiveNamedItemPost
 	 *
-	 *	It called when a player receives a item.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param sClassname		Classname item.
-	 * @param Item				Customization item.
-	 * @param iEnt				Index Entities item.
-	 * @param OriginIsNULL		True if Origin is NULL_VECTOR.
-	 * @param Origin			Coordinates where the item was created at (You cannot compare Origin == NULL_VECTOR, use OriginIsNULL param for it).
-	 *	-
+	 * It called when a player receives a item.
+	 *
+	 * @param iClient       Client index.
+	 * @param sClassname    Weapon classname.
+	 * @param pItemView     Customization item.
+	 * @param iEntity       Entity index. -1 if invalid item.
+	 * @param bOriginNULL   Origin is unspecified.
+	 * @param vecOrigin     Coordinates where the item was created.
+	 *
 	 * @noreturn
-	*/
-	function void (int iClient, const char[] sClassname, const CEconItemView Item, int iEnt, bool OriginIsNULL, const float Origin[3]);
-	
+	 */
+	function void (int iClient, const char[] sClassname, const CEconItemView pItemView, int iEntity, bool bOriginNULL, const float vecOrigin[3]);
+
 	/** WeaponCanUsePre
 	 *
-	 *	Called when a player is trying to pickup the item.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param iEnt				Index Entities item.
-	 * @param bCanUse			Can be picked up.
-	 *	-
-	 * @return	Return Plugin_Stop or Plugin_Handled to forbid lifting. Return Plugin_Continue to leave unchanged. Return Plugin_Changed to apply the changes specified in bCanUse.
-	*/
-	function Action (int iClient, int iEnt, bool& bCanUse);
-	
+	 * Called when a player is trying to pickup the item.
+	 *
+	 * @param iClient       Client index.
+	 * @param iEntity       Entity index.
+	 * @param bCanUs        Is can be picked up.
+	 *
+	 * @return              Return Plugin_Stop or Plugin_Handled to forbid lifting.
+	 *                      Return Plugin_Continue to leave unchanged.
+	 *                      Return Plugin_Changed to apply the changes specified in bCanUse.
+	 */
+	function Action (int iClient, int iEntity, bool &bCanUse);
+
 	/** WeaponCanUsePost
 	 *
 	 *	Called when a player attempted to pick up an item.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param iEnt				Index Entities item.
-	 * @param bCanUse			Can be picked up.
-	 *	-
+	 *
+	 * @param iClient       Client index.
+	 * @param iEntity       Entity index.
+	 * @param bCanUs        Is can be picked up.
+	 *
 	 * @noreturn
-	*/
-	function void (int iClient, int iEnt, bool bCanUse);
-	
+	 */
+	function void (int iClient, int iEntity, bool bCanUse);
+
 	/** SetPlayerModelPre
 	 *
-	 *	Called before changing the player model.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param sModel			The path to the current model player.
-	 * @param sNewModel			The path to a new model.
-	 *	-
-	 * @return	Return Plugin_Stop or Plugin_Handled stop changing models. Returns Plugin_Continue allow change model without changes. Returns Plugin_Changed allow the change to the modified model.
-	*/
+	 * Called before changing the player model.
+	 *
+	 * @param iClient       Client index.
+	 * @param sModel        Path to the player model.
+	 * @param sNewModel     Path to a new model for change.
+	 *
+	 * @return              Return Plugin_Stop or Plugin_Handled stop changing models.
+	 *                      Return Plugin_Continue for allow change model without changes.
+	 *                      Return Plugin_Changed for allow the change to the modified model.
+	 */
 	function Action (int iClient, const char[] sModel, char sNewModel[256]);
-	
+
 	/** SetPlayerModelPost
 	 *
-	 *	Called after the change of the player model.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param sModel			The path to the model.
-	 *	-
+	 * Called after the change of the player model.
+	 *
+	 * @param iClient       Client index.
+	 * @param sModel        Path to the player model.
+	 *
 	 * @noreturn
-	*/
+	 */
 	function void (int iClient, const char[] sModel);
-	
+
 	/** ClientVoiceToPre
 	 *
-	 *	Called when a player tries to speak.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param iTarget			Player target Index.
-	 * @param bListen			Can iTarget hear iClient.
-	 *	-
-	 * @return	Return Plugin_Stop or Plugin_Handled so that iTarget does not hear iClient. Return Plugin_Continue to leave unchanged. Return Plugin_Changed to apply the changes specified in bListen.
-	*/
-	function Action (int iClient, int iTarget, bool& bListen);
-	
+	 * Called when a player tries to speak.
+	 *
+	 * @param iClient       Client index.
+	 * @param iTarget       Player target Index.
+	 * @param bListen       Can iTarget hear iClient.
+	 *
+	 * @return              Return Plugin_Stop or Plugin_Handled so that iTarget does not hear iClient.
+	 *                      Return Plugin_Continue to leave unchanged. Return Plugin_Changed to apply the changes specified in bListen.
+	 */
+	function Action (int iClient, int iTarget, bool &bListen);
+
 	/** ClientVoiceToPost
 	 *
-	 *	Called after the player tried to speak.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param iTarget			Player target Index.
-	 * @param bListen			Can iTarget hear iClient.
-	 *	-
+	 * Called after the player tried to speak.
+	 *
+	 * @param iClient       Client index.
+	 * @param iTarget       Player target Index.
+	 * @param bListen       Can iTarget hear iClient.
+	 *
 	 * @noreturn
-	*/
+	 */
 	function void (int iClient, int iTarget, bool bListen);
-	
+
 	/** ConsolePrintPre
 	 *
-	 *	Called before displaying messages to the console player.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param sMessage			Text Message.
-	 *	-
-	 * @return	Return Plugin_Stop or Plugin_Handled restrict display message. Return Plugin_Continue allow the display message without changes. Return Plugin_Changed allow display changed message.
-	 *	-
+	 * Called before displaying messages to the console player.
+	 *
+	 * @param iClient       Client index.
+	 * @param sMessage      Text message.
+	 *
+	 * @return              Return Plugin_Stop or Plugin_Handled for restrict display message.
+	 *                      Return Plugin_Continue for allow the display message without changes.
+	 *                      Return Plugin_Changed for allow display changed message.
+	 *
 	 */
 	function Action (int iClient, char sMessage[1024]);
-	
+
 	/** ConsolePrintPost
 	 *
-	 *	Called after displaying messages to the console player.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param sMessage			Text Message.
-	 *	-
+	 * Called after displaying messages to the console player.
+	 *
+	 * @param iClient       Client index.
+	 * @param sMessage      Message text.
+	 *
 	 * @noreturn
-	 *	-
 	 */
 	function void (int iClient, const char[] sMessage);
-	
+
 	/** ExecuteStringCommandPre
 	 *
-	 *	Called before executing the command player of the team on the server.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param sCommandString	Command.
-	 *	-
-	 * @return	Return Plugin_Stop or Plugin_Handled restrict execution. Return Plugin_Continue allow execution without changes. Return Plugin_Changed allow execution with changes.
-	*/
-	function Action (int iClient, char sCommandString[512]);
-	
+	 * Called before executing the command player of the team on the server.
+	 *
+	 * @param iClient       Client index.
+	 * @param sCommand      Execute command.
+	 *
+	 * @return              Return Plugin_Stop or Plugin_Handled for restrict execution.
+	 *                      Return Plugin_Continue for allow execution without changes.
+	 *                      Return Plugin_Changed for allow execution with changes.
+	 */
+	function Action (int iClient, char sCommand[512]);
+
 	/** ExecuteStringCommandPost
 	 *
-	 *	Called after executing the command player of the server.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param sCommandString	Command.
-	 *	-
+	 * Called after executing the command player of the server.
+	 *
+	 * @param iClient       Client index.
+	 * @param sCommand      Execute command.
+	 *
 	 * @noreturn
-	*/
-	function void (int iClient, const char[] sCommandString);
-	
+	 */
+	function void (int iClient, const char[] sCommand);
+
 	/** ClientConnectPre
 	 *
-	 *	Called before the authorization of the client to the server.
-	 *	-
-	 * @param iAccountID		AccountID client.
-	 * @param sIp				IP client.
-	 * @param sName				Nickname client.
-	 * @param sPassword			Password witch he introduced.
-	 * @param rejectReason		The reason is not authorized.
-	 *	-
-	 * @return	Return Plugin_Stop or Plugin_Handled restrict autherization client. Return Plugin_Continue allow autherization without changes. Return Plugin_Changed allow autherization with changes.
-	*/
-	function Action (int iAccountID, const char[] sIp, const char[] sName, char sPassword[128], char rejectReason[255]);
-	
+	 * Called before the authorization of the client to the server.
+	 *
+	 * @param iAccountID    Client Steam account ID.
+	 * @param sIP           Client IP address.
+	 * @param sName         Client nickname.
+	 * @param sPassword     Password witch he introduced.
+	 * @param sRejectReason The reason is not authorized.
+	 *
+	 * @return              Return Plugin_Stop or Plugin_Handled for restrict autherization client.
+	 *                      Return Plugin_Continue for allow autherization without changes.
+	 *                      Return Plugin_Changed for allow autherization with changes.
+	 */
+	function Action (int iAccountID, const char[] sIP, const char[] sName, char sPassword[128], char sRejectReason[255]);
+
 	/** ClientConnectPost
 	 *
-	 *	Called after the authorization of the client to the server.
-	 *	-
-	 * @param iClient			Player Index.
-	 * @param iAccountID		AccountID client.
-	 * @param sIp				IP client.
-	 * @param sName				Nickname client.
-	 *	-
+	 * Called after the authorization of the client to the server.
+	 *
+	 * @param iClient       Client index.
+	 * @param iAccountID    Client Steam account ID.
+	 * @param sIP           Client IP address.
+	 * @param sName         Client nickname.
+	 *
 	 * @noreturn
-	*/
-	function void (int iClient, int iAccountID, const char[] sIp, const char[] sName);
+	 */
+	function void (int iClient, int iAccountID, const char[] sIP, const char[] sName);
+
+	/** InventoryUpdatePost
+	 *
+	 * Called after action in the player inventory.
+	 *
+	 * @param iClient       Client index.
+	 * @param pInventory    Pointer in CCSPlayerInventory.
+	 *
+	 * @noreturn
+	 */
+	function void (int iClient, CCSPlayerInventory pInventory);
 };
 
 
 
 /**
- *	PTaH Version.
- * @param sBuffer				The string will be written version (only need to specify if you want to get the version as a string).
- * @param len					Length of the line.
- *	-
- * @return	Return PTaH Version (or example 108, sBuffer = "1.0.8").
-*/
-native int PTaH_Version(char[] sBuf = NULL_STRING, int iLen = 0);
+ * Gets PTaH Version.
+ *
+ * @param sBuffer       Destination string buffer.
+ * @param iLen          Maximum length of output string buffer..
+ *
+ * @return              Return PTaH int Version. Example: 108 if sBuffer = "1.0.8".
+ */
+native int PTaH_Version(char[] sBuffer = NULL_STRING, int iLen = 0);
 
 /**
- *	Enables Hook.
- * @param typeEvent				Event hook.
- * @param type					Hook/Unhook.
- * @param callback				Callback.
- *	-
- * @return	Return true if one is fortunate, otherwise false.
-*/
-native bool PTaH(PTaH_HookEvent typeEvent, PTaH_HookType type, PTaHCB callback);
+ * Enables Hook.
+ *
+ * @param EventType     Event type.
+ * @param HookType      Hook/Unhook.
+ * @param Callback      Callback.
+ *
+ * @return              Is hook successful.
+ *
+ * @error               Invalid PTaH_HookEvent type.
+ */
+native bool PTaH(PTaH_HookEvent EventType, PTaH_HookType HookType, PTaHCB Callback);
 
 /**
- *	Gets CEconItemDefinition from ClassName weapons.
- * @param sClassName				ClassName weapons.
- *	-
- * @return	Returns CEconItemDefinition.
-*/
-native CEconItemDefinition PTaH_GetItemDefinitionByName(const char[] sClassName);
+ * Gets CEconItemDefinition from weapon classname.
+ *
+ * @param sClassname    Weapon classname.
+ *
+ * @return              Returns pointer in CEconItemDefinition.
+ */
+native CEconItemDefinition PTaH_GetItemDefinitionByName(const char[] sClassname);
 
 /**
- *	Gets CEconItemDefinition from DefinitionIndex.
- * @param iDefIndex					DefinitionIndex weapons.
- *	-
- * @return	Returns CEconItemDefinition.
-*/
+ * Gets CEconItemDefinition from definition index.
+ *
+ * @param iDefIndex     Definition index.
+ *
+ * @return              Returns CEconItemDefinition.
+ */
 native CEconItemDefinition PTaH_GetItemDefinitionByDefIndex(int iDefIndex);
 
 /**
- *	Gets CEconItemView weapons client.
- * @param iClient					Index Client.
- * @param iTeam						Index Commands.
- * @param iLoadoutSlot				Index Slot Weapons.
- *	-
- * @return	Returns CEconItemDefinition.
- *	-
- * @error invalid iClient, !(2 <= iTeam <= 3).
-*/
-native CEconItemView PTaH_GetItemInLoadout(int iClient, int iTeam, int iLoadoutSlot);
+ * Gets CEconItemView from entity with type DT_EconEntity.
+ *
+ * @param iEntity       Entity index.
+ *
+ * @return              Returns pointer in CEconItemView.
+ *
+ * @error               Invalid entity or entity type DT_EconEntity is not found.
+ */
+native CEconItemView PTaH_GetEconItemViewFromEconEntity(int iEntity);
 
 /**
- *	Gets CEconItemView weapons.
- * @param iEnt					Index weapons.
- *	-
- * @return	Returns CEconItemDefinition.
- *	-
- * @error invalid iEnt, iEnt not a weapon
-*/
-native CEconItemView PTaH_GetEconItemViewFromWeapon(int iEnt);
+ * Gets CCSPlayerInventory of Player.
+ *
+ * @note Use event hook "player_spawn" for get an early
+ * stage of loading Shared Data in the inventory
+ *
+ * @param iClient       Client index.
+ *
+ * @return              Returns pointer in CCSPlayerInventory.
+ *
+ * @error               Invalid client index.
+ */
+native CCSPlayerInventory PTaH_GetPlayerInventory(int iClient);
 
 /**
- *	It gives the player item with the specified CEconItemView.
- * @param iClient				Index Player.
- * @param sClassname			Classname item.
- * @param Item					Customization item.
- * @param Origin				Coordinates the item will be created at, or NULL_VECTOR.
- *	-
- * @return	Return index item.
- *	-
- * @error invalid iClient.
-*/
-native int PTaH_GivePlayerItem(int iClient, const char[] sClassname, CEconItemView Item = CEconItemView_NULL, const float Origin[3] = NULL_VECTOR);
+ * It gives the player item with the specified CEconItemView.
+ *
+ * @param iClient       Client index.
+ * @param sClassname    Item classname.
+ * @param pItemView     Customization item.
+ * @param vecOrigin     Coordinates the item will be created at, or NULL_VECTOR.
+ *
+ * @return              Return entity index.
+ *
+ * @error               Invalid client index.
+ */
+native int PTaH_GivePlayerItem(int iClient, const char[] sClassname, CEconItemView pItemView = CEconItemView_NULL, const float vecOrigin[3] = NULL_VECTOR);
 
 /**
- *	Sends to Player a full update packet.
- * @param iClient				Index Player.
- *	-
+ * Sends to player a full update packet.
+ *
+ * @param iClient       Client index.
+ *
  * @noreturn
- *	-
- * @error invalid iClient.
-*/
+ *
+ * @error               Invalid client index.
+ */
 native void PTaH_ForceFullUpdate(int iClient);
 
 /**
- *  Spawn item by a definition index at the coordionates.
- * @param iDefIndex			The definition index (allowed only weapon_* and item_*).
- * @param Origin				Coordinates the item will be created at.
- * @param Angles				Angles the item will be created at.
- * -
- * @return Return index item.
- * -
- * @error NULL_VECTOR in Origin or Angles arguments, iDefIndex invalid.
-*/
-native int PTaH_SpawnItemFromDefIndex(int iDefIndex, const float Origin[3], const float Angles[3] = {0.0, 0.0, 0.0});
+ * Spawn item by a definition index at the coordionates.
+ *
+ * @param iDefIndex     Definition index.
+ * @param vecOrigin     Coordinates the item will be created at.
+ * @param flAngles      Angles the item will be created at.
+ *
+ * @return              Return index item.
+ *
+ * @error               vecOrigin == NULL_VECTOR or invalid definition index.
+ */
+native int PTaH_SpawnItemFromDefIndex(int iDefIndex, const float vecOrigin[3], const float flAngles[3] = {0.0, 0.0, 0.0});
 
 /**
- *  Emulate bullet shot on the server and does the damage calculations.
- * @param iClient				The Player Index.
- * @param Item					Customization item.
- * @param Origin				Coordinates the bullet will be created at.
- * @param Angles				Angles the bullet will be created at.
- * @param iMode					Mode index.
- * @param iSeed					Randomizing seed.
- * @param fInaccuracy			Inaccuracy variable.
- * @param fSpread				Spread variable.
- * @param fFishtail				Accuracy Fishtail.
- * @param iSoundType			Sound type. (1 or 12 for silenced, 0 for none sound)
- * @param fRecoilIndex			Recoil variable.
- *	-
+ * Emulate bullet shot on the server and does the damage calculations.
+ *
+ * @param iClient       Client index.
+ * @param pItemView     Customization item.
+ * @param vecOrigin     Coordinates the bullet will be created at.
+ * @param flAngles      Angles the bullet will be created at.
+ * @param iMode         Mode index.
+ * @param iSeed         Randomizing seed.
+ * @param flInaccuracy  Inaccuracy variable.
+ * @param flSpread      Spread variable.
+ * @param flFishtail    Accuracy Fishtail.
+ * @param iSoundType    Sound type. (1 or 12 for silenced, 0 for none sound)
+ * @param flRecoilIndex Recoil variable.
+ *
  * @noreturn
- *	-
- * @error invalid iClient, NULL_VECTOR in Origin or Angles arguments, CEconItemView == NULL.
-*/
-native void PTaH_FX_FireBullets(int iClient, CEconItemView Item, const float Origin[3], const float Angles[3], int iMode, int iSeed, float fInaccuracy, float fSpread, float fFishtail, int iSoundType, float fRecoilIndex);
+ *
+ * @error               Invalid client index or CEconItemView == NULL or vecOrigin == NULL_VECTOR.
+ */
+native void PTaH_FX_FireBullets(int iClient, CEconItemView pItemView, const float vecOrigin[3], const float flAngles[3], int iMode, int iSeed, float flInaccuracy, float flSpread, float flFishtail, int iSoundType, float flRecoilIndex);
+
+#pragma deprecated Use CCSPlayerInventory::GetItemInLoadout() instead
+native CEconItemView PTaH_GetItemInLoadout(int iClient, int iTeam, int iLoadoutSlot);
+
+#pragma deprecated Use PTaH_GetEconItemViewFromEconEntity() instead
+native CEconItemView PTaH_GetEconItemViewFromWeapon(int iEntity);
 
 
 
@@ -581,8 +771,8 @@ public __ext_PTaH_SetNTVOptional()
 	MarkNativeAsOptional("PTaH");
 	MarkNativeAsOptional("PTaH_GetItemDefinitionByName");
 	MarkNativeAsOptional("PTaH_GetItemDefinitionByDefIndex");
-	MarkNativeAsOptional("PTaH_GetItemInLoadout");
-	MarkNativeAsOptional("PTaH_GetEconItemViewFromWeapon");
+	MarkNativeAsOptional("PTaH_GetEconItemViewFromEconEntity");
+	MarkNativeAsOptional("PTaH_GetPlayerInventory");
 	MarkNativeAsOptional("PTaH_GivePlayerItem");
 	MarkNativeAsOptional("PTaH_ForceFullUpdate");
 	MarkNativeAsOptional("PTaH_SpawnItemFromDefIndex");
@@ -605,5 +795,13 @@ public __ext_PTaH_SetNTVOptional()
 	MarkNativeAsOptional("CEconItemView.GetOrigin");
 	MarkNativeAsOptional("CEconItemView.GetCustomName");
 	MarkNativeAsOptional("CEconItemView.GetStatTrakKill");
+	MarkNativeAsOptional("CEconItemView.GetAttributeValueByIndex");
+	MarkNativeAsOptional("CCSPlayerInventory.GetItemInLoadout");
+	MarkNativeAsOptional("CCSPlayerInventory.GetItemsCount");
+	MarkNativeAsOptional("CCSPlayerInventory.GetItem");
+
+	// Deprecated
+	MarkNativeAsOptional("PTaH_GetItemInLoadout");
+	MarkNativeAsOptional("PTaH_GetEconItemViewFromWeapon");
 }
 #endif

--- a/PTaH.inc
+++ b/PTaH.inc
@@ -30,6 +30,13 @@ enum PTaH_HookEvent
 	PTaH_InventoryUpdatePost = 25
 };
 
+enum PTaH_ModelType
+{
+	ViewModel = 0,
+	WorldModel,
+	DroppedModel
+};
+
 enum EStickerAttributeType 
 {
 	StickerID = 0,        // int
@@ -44,7 +51,7 @@ enum EEconItemQuality
 
 	AE_NORMAL = 0,
 	AE_GENUINE = 1,
-	AE_VINTAGE,	
+	AE_VINTAGE,
 	AE_UNUSUAL,
 	AE_UNIQUE,
 	AE_COMMUNITY,
@@ -170,12 +177,41 @@ methodmap CEconItemDefinition
 	public native int GetNumSupportedStickerSlots();
 
 	/**
+	 * Gets item econ image path in resource/flash/.
+	 * Example: "econ/weapons/base_weapons/weapon_knife"
+	 *
+	 * @note Add ".png" in the end of string for full formatting.
+	 *
+	 * @param sBuffer      Destination string buffer.
+	 * @param iLen         Maximum length of output string buffer.
+	 *
+	 * @return             Returns length or 0 if failed.
+	 *
+	 * @error              CEconItemDefinition == NULL.
+	 */
+	public native int GetEconImage(char[] sBuffer, int iLen);
+
+	/**
+	 * Gets item model path.
+	 *
+	 * @param iModelType   Model type.
+	 * @param sBuffer      Destination string buffer.
+	 * @param iLen         Maximum length of output string buffer.
+	 *                     Max size PLATFORM_MAX_PATH.
+	 *
+	 * @return             Returns length or 0 if failed.
+	 *
+	 * @error              CEconItemDefinition == NULL or model type invalid.
+	 */
+	public native int GetModel(PTaH_ModelType iModelType, char[] sBuffer, int iLen);
+
+	/**
 	 * Gets item classname.
 	 *
 	 * @param sBuffer      Destination string buffer.
 	 * @param iLen         Maximum length of output string buffer.
 	 *
-	 * @return             Returns classname length.
+	 * @return             Returns length or 0 if failed.
 	 *
 	 * @error              CEconItemDefinition == NULL.
 	 */
@@ -265,6 +301,17 @@ methodmap CEconItemView
 	 * @error              CEconItemView == NULL.
 	 */
 	public native int GetAccountID();
+
+	/**
+	 * Gets ItemID of ItemView.
+	 *
+	 * @param iItemID      Where will it be recorded ItemID.
+	 *
+	 * @noreturn
+	 *
+	 * @error              CEconItemView == NULL.
+	 */
+	public native void GetItemID(int iItemID[2]);
 
 	/**
 	 * Gets owner of ItemView.
@@ -780,15 +827,18 @@ public __ext_PTaH_SetNTVOptional()
 	MarkNativeAsOptional("CEconItemDefinition.GetDefinitionIndex");
 	MarkNativeAsOptional("CEconItemDefinition.GetLoadoutSlot");
 	MarkNativeAsOptional("CEconItemDefinition.GetNumSupportedStickerSlots");
+	MarkNativeAsOptional("CEconItemDefinition.GetEconImage");
+	MarkNativeAsOptional("CEconItemDefinition.GetModel");
 	MarkNativeAsOptional("CEconItemDefinition.GetClassName");
 	MarkNativeAsOptional("CEconItemView.GetCustomPaintKitIndex");
 	MarkNativeAsOptional("CEconItemView.GetCustomPaintKitSeed");
 	MarkNativeAsOptional("CEconItemView.GetCustomPaintKitWear");
 	MarkNativeAsOptional("CEconItemView.GetStickerAttributeBySlotIndex");
 	MarkNativeAsOptional("CEconItemView.IsTradable");
-	MarkNativeAsOptional("CEconItemView.IsMarketable");	
+	MarkNativeAsOptional("CEconItemView.IsMarketable");
 	MarkNativeAsOptional("CEconItemView.GetItemDefinition");
 	MarkNativeAsOptional("CEconItemView.GetAccountID");
+	MarkNativeAsOptional("CEconItemView.GetItemID");
 	MarkNativeAsOptional("CEconItemView.GetQuality");
 	MarkNativeAsOptional("CEconItemView.GetRarity");
 	MarkNativeAsOptional("CEconItemView.GetFlags");

--- a/classes.cpp
+++ b/classes.cpp
@@ -75,11 +75,11 @@ CEconItemDefinition* CEconItemSchema::GetItemDefinitionByDefIndex(uint16_t DefIn
 	if (DefIndex > 0)
 	{
 		//See GetItemDefinitionByMapIndex
-		struct ItemMapMember
+		struct ItemMapMember		// CUtlHashMapLarge<int, CEconItemDefinition*, MurmurHash3Functor<int> >
 		{
-			uint16_t DefIndex;
-			CEconItemDefinition* ItemDefinition;
-			int Unknown;
+			uint16_t iDefIndex;
+			CEconItemDefinition* pItemDefinition;
+			int iHash;
 		};
 
 		ItemMapMember* MapMember = nullptr;
@@ -90,7 +90,7 @@ CEconItemDefinition* CEconItemSchema::GetItemDefinitionByDefIndex(uint16_t DefIn
 		{
 			MapMember = (ItemMapMember*)(ItemMap + i * sizeof(ItemMapMember));
 
-			if (MapMember->DefIndex == DefIndex) return MapMember->ItemDefinition;
+			if (MapMember->iDefIndex == DefIndex) return MapMember->pItemDefinition;
 		}
 	}
 
@@ -163,6 +163,74 @@ int CEconItemDefinition::GetNumSupportedStickerSlots()
 	}
 
 	return ((int(VCallingConvention*)(void*))(*(void***)this)[offset])(this);
+}
+
+const char* CEconItemDefinition::GetEconImage()
+{
+	static int offset = -1;
+
+	if (offset == -1)
+	{
+		if (!g_pGameConf[GameConf_PTaH]->GetOffset("GetEconImage", &offset))
+		{
+			smutils->LogError(myself, "Failed to get GetEconImage offset.");
+
+			return nullptr;
+		}
+	}
+
+	return *(const char**)(this + offset);
+}
+
+const char* CEconItemDefinition::GetViewModel()
+{
+	static int offset = -1;
+
+	if (offset == -1)
+	{
+		if (!g_pGameConf[GameConf_PTaH]->GetOffset("GetViewModel", &offset))
+		{
+			smutils->LogError(myself, "Failed to get GetViewModel offset.");
+
+			return nullptr;
+		}
+	}
+
+	return *(const char**)(this + offset);
+}
+
+const char* CEconItemDefinition::GetWorldModel()
+{
+	static int offset = -1;
+
+	if (offset == -1)
+	{
+		if (!g_pGameConf[GameConf_PTaH]->GetOffset("GetWorldModel", &offset))
+		{
+			smutils->LogError(myself, "Failed to get GetWorldModel offset.");
+
+			return nullptr;
+		}
+	}
+
+	return *(const char**)(this + offset);
+}
+
+const char* CEconItemDefinition::GetDroppedModel()
+{
+	static int offset = -1;
+
+	if (offset == -1)
+	{
+		if (!g_pGameConf[GameConf_PTaH]->GetOffset("GetDroppedModel", &offset))
+		{
+			smutils->LogError(myself, "Failed to get GetDroppedModel offset.");
+
+			return nullptr;
+		}
+	}
+
+	return *(const char**)(this + offset);
 }
 
 const char* CEconItemDefinition::GetClassName()
@@ -333,6 +401,23 @@ int CEconItemView::GetAccountID()
 	}
 
 	return ((int(VCallingConvention*)(void*))(*(void***)this)[offset])(this);
+}
+
+uint64_t CEconItemView::GetItemID()
+{
+	static int offset = -1;
+
+	if(offset == -1)
+	{
+		if(!g_pGameConf[GameConf_PTaH]->GetOffset("GetItemID", &offset))
+		{
+			smutils->LogError(myself, "Failed to get GetItemID offset.");
+
+			return -1;
+		}
+	}
+
+	return ((uint64_t(VCallingConvention*)(void*))(*(void***)this)[offset])(this);
 }
 
 int CEconItemView::GetQuality()

--- a/classes.h
+++ b/classes.h
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod P Tools and Hooks Extension
- * Copyright (C) 2016-2019 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
+ * Copyright (C) 2016-2020 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -21,7 +21,6 @@
 #ifndef _INCLUDE_SOURCEMOD_EXTENSION_CLASSES_H_
 #define _INCLUDE_SOURCEMOD_EXTENSION_CLASSES_H_
 
-class CEconItemAttributeDefinition;
 class CAttribute_String;
 
 enum EStickerAttributeType
@@ -30,6 +29,41 @@ enum EStickerAttributeType
 	WearProgress,
 	PatternScale,
 	PatternRotation
+};
+
+class ISchemaAttributeType
+{
+protected:
+	virtual ~ISchemaAttributeType() { }
+};
+
+template<typename T> class ISchemaAttributeTypeBase : public ISchemaAttributeType {};
+template<typename T> class CSchemaAttributeTypeBase : public ISchemaAttributeTypeBase<T> {};
+template<typename T> class CSchemaAttributeTypeProtobufBase : public CSchemaAttributeTypeBase<T> {};
+
+class CSchemaAttributeType_Default : public CSchemaAttributeTypeBase<unsigned int> {};
+class CSchemaAttributeType_Uint32 : public CSchemaAttributeTypeBase<unsigned int> {};
+class CSchemaAttributeType_Float : public CSchemaAttributeTypeBase<float> {};
+class CSchemaAttributeType_String : public CSchemaAttributeTypeProtobufBase<CAttribute_String> {};
+class CSchemaAttributeType_Vector : public CSchemaAttributeTypeBase<Vector> {};
+
+class CEconItemAttributeDefinition
+{
+public:
+	virtual uint16_t GetDefinitionIndex() const = 0;
+	virtual const char* GetDefinitionName() const = 0;
+	virtual const char* GetDescriptionString() const = 0;
+	virtual const char* GetAttributeClass() const = 0;
+	virtual const KeyValues* GetRawDefinition() const = 0;
+
+	template<typename T> bool IsAttributeType() const
+	{
+		return (dynamic_cast<T*>(this->m_pAttributeType) != nullptr);
+	}
+
+	KeyValues* m_pKVAttribute;
+	uint16_t m_nDefIndex;
+	ISchemaAttributeType* m_pAttributeType;
 };
 
 class CEconItemDefinition
@@ -156,6 +190,17 @@ public:
 };
 
 #define IClientToGameClient(pClient) (CGameClient*)((intptr_t)(pClient) - sizeof(void*))
+
+class CCSPlayerInventory
+{
+	static intptr_t GetInventoryOffset();
+public:
+	static CCSPlayerInventory* FromPlayer(CBaseEntity* pPlayer);
+	CBaseEntity* ToPlayer();
+
+	CEconItemView* GetItemInLoadout(int iTeam, int iLoadoutSlot);
+	CUtlVector<CEconItemView*>* GetItems();
+};
 
 
 extern CEconItemSchema* g_pCEconItemSchema;

--- a/classes.h
+++ b/classes.h
@@ -72,6 +72,10 @@ public:
 	uint16_t GetDefinitionIndex();
 	int GetLoadoutSlot(int iTeam);
 	int GetNumSupportedStickerSlots();
+	const char* GetEconImage();
+	const char* GetViewModel();
+	const char* GetWorldModel();
+	const char* GetDroppedModel();
 	const char* GetClassName();
 };
 
@@ -108,6 +112,7 @@ public:
 	bool IsMarketable();
 	CEconItemDefinition* GetItemDefinition();
 	int GetAccountID();
+	uint64_t GetItemID();
 	int GetQuality();
 	int GetRarity();
 	int GetFlags();

--- a/extension.cpp
+++ b/extension.cpp
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod P Tools and Hooks Extension
- * Copyright (C) 2016-2019 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
+ * Copyright (C) 2016-2020 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/extension.h
+++ b/extension.h
@@ -66,6 +66,13 @@ enum PTaH_HookEvent
 	PTaH_MAXHOOKS
 };
 
+enum PTaH_ModelType
+{
+	ViewModel = 0,
+	WorldModel,
+	DroppedModel
+};
+
 /**
  * @brief Sample implementation of the SDK Extension.
  * Note: Uncomment one of the pre-defined virtual functions in order to use it.

--- a/extension.h
+++ b/extension.h
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod P Tools and Hooks Extension
- * Copyright (C) 2016-2019 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
+ * Copyright (C) 2016-2020 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -61,6 +61,7 @@ enum PTaH_HookEvent
 	PTaH_ExecuteStringCommandPost,
 	PTaH_ClientConnectPre,
 	PTaH_ClientConnectPost,
+	PTaH_InventoryUpdatePost = 25,
 
 	PTaH_MAXHOOKS
 };
@@ -147,7 +148,7 @@ public:
 #define GameConf_PTaH 2
 #define GameConf_CSST 3
 
-extern IGameConfig * g_pGameConf[4];
+extern IGameConfig* g_pGameConf[4];
 extern ISDKTools* sdktools;
 extern IServer* iserver;
 extern IVoiceServer* voiceserver;

--- a/forwards.cpp
+++ b/forwards.cpp
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod P Tools and Hooks Extension
- * Copyright (C) 2016-2019 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
+ * Copyright (C) 2016-2020 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -52,6 +52,9 @@ SH_DECL_MANUALHOOK1(ExecuteStringCommand, 0, 0, 0, bool, const char*);
 SH_DECL_MANUALHOOK13(ConnectClient, 0, 0, 0, IClient*, const netadr_t&, int, int, int, const char*, const char*, const char*, int, CUtlVector<NetMsg_SplitPlayerConnect*>&, bool, CrossPlayPlatform_t, const unsigned char*, int);
 SH_DECL_MANUALHOOK1_void_vafmt(RejectConnection, 0, 0, 0, const netadr_t&);
 
+//InventoryUpdate
+SH_DECL_MANUALHOOK0_void(SendInventoryUpdateEvent, 0, 0, 0);
+
 
 void CForwardManager::Init()
 {
@@ -69,6 +72,7 @@ void CForwardManager::Init()
 	ExecuteStringCommandPost.Init();
 	ClientConnectPre.Init();
 	ClientConnectPost.Init();
+	InventoryUpdatePost.Init();
 
 	SH_ADD_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &CForwardManager::LevelShutdown), true);
 
@@ -102,6 +106,7 @@ void CForwardManager::Shutdown()
 	ExecuteStringCommandPost.Shutdown();
 	ClientConnectPre.Shutdown();
 	ClientConnectPost.Shutdown();
+	InventoryUpdatePost.Shutdown();
 }
 
 bool CForwardManager::FunctionUpdateHook(PTaH_HookEvent htType, IPluginFunction* pFunction, bool bHook)
@@ -122,6 +127,7 @@ bool CForwardManager::FunctionUpdateHook(PTaH_HookEvent htType, IPluginFunction*
 	case PTaH_ExecuteStringCommandPost: return ExecuteStringCommandPost.UpdateForward(pFunction, bHook);
 	case PTaH_ClientConnectPre: return ClientConnectPre.UpdateForward(pFunction, bHook);
 	case PTaH_ClientConnectPost: return ClientConnectPost.UpdateForward(pFunction, bHook);
+	case PTaH_InventoryUpdatePost: return InventoryUpdatePost.UpdateForward(pFunction, bHook);
 	}
 
 	return false;
@@ -153,6 +159,7 @@ void CForwardManager::OnClientPutInServer(int iClient)
 	WeaponCanUsePost.HookClient(iClient);
 	SetPlayerModelPre.HookClient(iClient);
 	SetPlayerModelPost.HookClient(iClient);
+	InventoryUpdatePost.Hook(iClient);
 }
 
 void CForwardManager::OnClientDisconnected(int iClient)
@@ -181,6 +188,12 @@ void CForwardManager::OnPluginUnloaded(IPlugin* plugin)
 	ExecuteStringCommandPost.UpdateHook();
 	ClientConnectPre.UpdateHook();
 	ClientConnectPost.UpdateHook();
+	InventoryUpdatePost.UpdateHook();
+}
+
+CForwardManager::TempleHookClient::TempleHookClient()
+{
+	memset(iHookId, 0xFF, sizeof(iHookId));
 }
 
 void CForwardManager::TempleHookClient::Shutdown()
@@ -190,7 +203,7 @@ void CForwardManager::TempleHookClient::Shutdown()
 
 void CForwardManager::TempleHookClient::UpdateHook()
 {
-	if (pForward->GetFunctionCount() > 0 != bHooked)
+	if (iOffset != -1 && pForward->GetFunctionCount() > 0 != bHooked)
 	{
 		bHooked = !bHooked;
 
@@ -249,8 +262,7 @@ bool CForwardManager::TempleHookClient::UpdateForward(IPluginFunction* pFunc, bo
 	return false;
 }
 
-
-void CForwardManager::TempleHookCGameClient::Shutdown()
+void CForwardManager::TempleHookVP::Shutdown()
 {
 	if (iOffset != -1)
 	{
@@ -260,18 +272,7 @@ void CForwardManager::TempleHookCGameClient::Shutdown()
 	}
 }
 
-void CForwardManager::TempleHookCGameClient::Hook(int iClient)
-{
-	if (bHooked && iHookId == -1)
-	{
-		IClient* pClient = iserver->GetClient(iClient - 1);
-		CGameClient* pGameClient = __IClientToGameClient(pClient);
-
-		iHookId = __SH_ADD_MANUALVPHOOK(pGameClient);
-	}
-}
-
-bool CForwardManager::TempleHookCGameClient::UpdateForward(IPluginFunction* pFunc, bool bHook)
+bool CForwardManager::TempleHookVP::UpdateForward(IPluginFunction* pFunc, bool bHook)
 {
 	if (iOffset != -1)
 	{
@@ -288,9 +289,9 @@ bool CForwardManager::TempleHookCGameClient::UpdateForward(IPluginFunction* pFun
 	return false;
 }
 
-void CForwardManager::TempleHookCGameClient::UpdateHook()
+void CForwardManager::TempleHookVP::UpdateHook()
 {
-	if (pForward->GetFunctionCount() > 0 != bHooked)
+	if (iOffset != -1 && pForward->GetFunctionCount() > 0 != bHooked)
 	{
 		bHooked = !bHooked;
 
@@ -299,7 +300,9 @@ void CForwardManager::TempleHookCGameClient::UpdateHook()
 			IGamePlayer* pPlayer;
 			int iMaxClients = playerhelpers->GetMaxClients();
 
-			for (int i = 1; i <= iMaxClients; i++) if ((pPlayer = playerhelpers->GetGamePlayer(i)) && pPlayer->IsConnected())
+			auto fPlayerValid = bInGame ? &IGamePlayer::IsInGame : &IGamePlayer::IsConnected;
+
+			for (int i = 1; i <= iMaxClients; i++) if ((pPlayer = playerhelpers->GetGamePlayer(i)) && (pPlayer->*fPlayerValid)())
 			{
 				Hook(i);
 
@@ -312,6 +315,17 @@ void CForwardManager::TempleHookCGameClient::UpdateHook()
 
 			iHookId = -1;
 		}
+	}
+}
+
+void CForwardManager::TempleHookCGameClient::Hook(int iClient)
+{
+	if (bHooked && iHookId == -1)
+	{
+		IClient* pClient = iserver->GetClient(iClient - 1);
+		CGameClient* pGameClient = __IClientToGameClient(pClient);
+
+		iHookId = __SH_ADD_MANUALVPHOOK(pGameClient);
 	}
 }
 
@@ -431,7 +445,7 @@ void CForwardManager::GiveNamedItemPre::Shutdown()
 
 void CForwardManager::GiveNamedItemPre::UpdateHook()
 {
-	if (pForward->GetFunctionCount() > 0 != bHooked)
+	if (iOffset != -1 && pForward->GetFunctionCount() > 0 != bHooked)
 	{
 		bHooked = !bHooked;
 
@@ -665,7 +679,7 @@ bool CForwardManager::ClientVoiceToPre::UpdateForward(IPluginFunction* pFunc, bo
 
 void CForwardManager::ClientVoiceToPre::UpdateHook()
 {
-	if (pForward->GetFunctionCount() > 0 != bHooked)
+	if (g_pCPlayerVoiceListener && pForward->GetFunctionCount() > 0 != bHooked)
 	{
 		bHooked = !bHooked;
 
@@ -762,7 +776,7 @@ bool CForwardManager::ClientVoiceToPost::UpdateForward(IPluginFunction* pFunc, b
 
 void CForwardManager::ClientVoiceToPost::UpdateHook()
 {
-	if (pForward->GetFunctionCount() > 0 != bHooked)
+	if (g_pCPlayerVoiceListener && pForward->GetFunctionCount() > 0 != bHooked)
 	{
 		bHooked = !bHooked;
 
@@ -954,7 +968,7 @@ bool CForwardManager::ClientConnectPre::UpdateForward(IPluginFunction* pFunc, bo
 
 void CForwardManager::ClientConnectPre::UpdateHook()
 {
-	if (pForward->GetFunctionCount() > 0 != bHooked)
+	if (iOffset != -1 && pForward->GetFunctionCount() > 0 != bHooked)
 	{
 		bHooked = !bHooked;
 
@@ -1072,7 +1086,7 @@ bool CForwardManager::ClientConnectPost::UpdateForward(IPluginFunction* pFunc, b
 
 void CForwardManager::ClientConnectPost::UpdateHook()
 {
-	if (pForward->GetFunctionCount() > 0 != bHooked)
+	if (iOffset != -1 && pForward->GetFunctionCount() > 0 != bHooked)
 	{
 		bHooked = !bHooked;
 
@@ -1108,4 +1122,43 @@ IClient* CForwardManager::ClientConnectPost::SHHook(const netadr_t& address, int
 	}
 
 	RETURN_META_VALUE(MRES_IGNORED, nullptr);
+}
+
+CForwardManager::SendInventoryUpdateEventPost::SendInventoryUpdateEventPost()
+{
+	bInGame = true;
+}
+
+void CForwardManager::SendInventoryUpdateEventPost::Init()
+{
+	if (g_pGameConf[GameConf_PTaH]->GetOffset("SendInventoryUpdateEvent", &iOffset))
+	{
+		SH_MANUALHOOK_RECONFIGURE(SendInventoryUpdateEvent, iOffset, 0, 0);
+
+		pForward = forwards->CreateForwardEx(nullptr, ET_Hook, 2, nullptr, Param_Cell, Param_Cell);
+	}
+	else smutils->LogError(myself, "Failed to get SendInventoryUpdateEvent offset, Hook InventoryUpdatePost will be unavailable.");
+}
+
+void CForwardManager::SendInventoryUpdateEventPost::Hook(int iClient)
+{
+	if (bHooked && iHookId == -1)
+	{
+		CBaseEntity* pEntity = gamehelpers->ReferenceToEntity(iClient);
+
+		CCSPlayerInventory* pPlayerInventory = CCSPlayerInventory::FromPlayer(pEntity);
+
+		iHookId = SH_ADD_MANUALVPHOOK(SendInventoryUpdateEvent, pPlayerInventory, SH_MEMBER(this, &CForwardManager::SendInventoryUpdateEventPost::SHHook), true);
+	}
+}
+
+void CForwardManager::SendInventoryUpdateEventPost::SHHook()
+{
+	CCSPlayerInventory* pPlayerInventory = META_IFACEPTR(CCSPlayerInventory);
+
+	pForward->PushCell(gamehelpers->EntityToBCompatRef(pPlayerInventory->ToPlayer()));
+	pForward->PushCell(reinterpret_cast<cell_t>(pPlayerInventory));
+	pForward->Execute(nullptr);
+
+	RETURN_META(MRES_IGNORED);
 }

--- a/forwards.cpp
+++ b/forwards.cpp
@@ -934,7 +934,7 @@ void CForwardManager::ClientConnectPre::Init()
 
 			pForward = pForward = forwards->CreateForwardEx(nullptr, ET_Hook, 5, nullptr, Param_Cell, Param_String, Param_String, Param_String, Param_String);
 		}
-		else smutils->LogError(myself, "Failed to get ConnectClient offset, Hook ClientConnectPost will be unavailable.");
+		else smutils->LogError(myself, "Failed to get ConnectClient offset, Hook ClientConnectPre will be unavailable.");
 	}
 	else smutils->LogError(myself, "Failed to get RejectConnection offset, Hook ClientConnectPre will be unavailable.");
 }

--- a/forwards.h
+++ b/forwards.h
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod P Tools and Hooks Extension
- * Copyright (C) 2016-2019 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
+ * Copyright (C) 2016-2020 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -58,6 +58,8 @@ public: // IPluginsListener
 	class TempleHookClient
 	{
 	public:
+		TempleHookClient();
+
 		virtual void Shutdown();
 		void HookClient(int iClient);
 		void UnHookClient(int iClient);
@@ -69,29 +71,38 @@ public: // IPluginsListener
 
 		IChangeableForward* pForward = nullptr;
 
-		int iHookId[SM_MAXPLAYERS + 1] = { -1 };
+		int iHookId[SM_MAXPLAYERS + 1];
 		bool bHooked = false;
 		int iOffset = -1;
 	};
 
-	class TempleHookCGameClient
+	class TempleHookVP
 	{
 	public:
 		void Shutdown();
-		void Hook(int iClient);
+		virtual void Hook(int iClient) = 0;
 		bool UpdateForward(IPluginFunction* pFunc, bool bHook);
 		void UpdateHook();
 
 	protected:
-		virtual int __SH_ADD_MANUALVPHOOK(CGameClient* pGameClient) = 0; //Crutch
-		inline CGameClient* __IClientToGameClient(IClient* pClient);
-		inline IClient* __GameClientToIClient(CGameClient* pGameClient);
-
 		IChangeableForward* pForward = nullptr;
 
 		int iHookId = -1;
 		bool bHooked = false;
 		int iOffset = -1;
+
+		bool bInGame = false;
+	};
+
+	class TempleHookCGameClient : public TempleHookVP
+	{
+	public:
+		virtual void Hook(int iClient) override;
+
+	protected:
+		virtual int __SH_ADD_MANUALVPHOOK(CGameClient* pGameClient) = 0; //Crutch
+		inline CGameClient* __IClientToGameClient(IClient* pClient);
+		inline IClient* __GameClientToIClient(CGameClient* pGameClient);
 	};
 
 	class GiveNamedItemPre : public TempleHookClient
@@ -180,7 +191,7 @@ public: // IPluginsListener
 
 		IChangeableForward* pForward = nullptr;
 
-		bool bStartVoice[SM_MAXPLAYERS + 1] = { false };
+		bool bStartVoice[SM_MAXPLAYERS + 1] = { };
 		bool bHooked = false;
 	} ClientVoiceToPre;
 
@@ -279,6 +290,18 @@ public: // IPluginsListener
 		int iOffset = -1;
 		int iHookId = -1;
 	} ClientConnectPost;
+
+	class SendInventoryUpdateEventPost : public TempleHookVP
+	{
+	public:
+		SendInventoryUpdateEventPost();
+
+		void Init();
+		virtual void Hook(int iClient) override;
+
+	protected:
+		void SHHook();
+	} InventoryUpdatePost;
 };
 
 extern CForwardManager g_ForwardManager;

--- a/natives.cpp
+++ b/natives.cpp
@@ -471,16 +471,82 @@ static cell_t PTaH_GetNumSupportedStickerSlots(IPluginContext* pContext, const c
 	return pContext->ThrowNativeError("CEconItemDefinition == nullptr");
 }
 
+static cell_t PTaH_GetEconImage(IPluginContext* pContext, const cell_t* params)
+{
+	CEconItemDefinition* pItemDefinition = reinterpret_cast<CEconItemDefinition*>(params[1]);
+
+	if (pItemDefinition)
+	{
+		size_t numBytes = 0;
+		const char* sBuf = pItemDefinition->GetEconImage();
+
+		if (sBuf)
+		{
+			pContext->StringToLocalUTF8(params[2], params[3], sBuf, &numBytes);
+		}
+
+		return numBytes;
+	}
+
+	return pContext->ThrowNativeError("CEconItemDefinition == nullptr");
+}
+
+static cell_t PTaH_GetModel(IPluginContext* pContext, const cell_t* params)
+{
+	CEconItemDefinition* pItemDefinition = reinterpret_cast<CEconItemDefinition*>(params[1]);
+
+	if (pItemDefinition)
+	{
+		size_t numBytes = 0;
+		const char* sBuf;
+
+		switch (static_cast<PTaH_ModelType>(params[2]))
+		{
+			case ViewModel:
+			{
+				sBuf = pItemDefinition->GetViewModel();
+				break;
+			}
+			case WorldModel:
+			{
+				sBuf = pItemDefinition->GetWorldModel();
+				break;
+			}
+			case DroppedModel:
+			{
+				sBuf = pItemDefinition->GetDroppedModel();
+				break;
+			}
+			default:
+			{
+				return pContext->ThrowNativeError("Invalid PTaH_ModelType value");
+			}
+		}
+
+		if (sBuf)
+		{
+			pContext->StringToLocalUTF8(params[3], params[4], sBuf, &numBytes);
+		}
+
+		return numBytes;
+	}
+
+	return pContext->ThrowNativeError("CEconItemDefinition == nullptr");
+}
+
 static cell_t PTaH_GetClassName(IPluginContext* pContext, const cell_t* params)
 {
 	CEconItemDefinition* pItemDefinition = reinterpret_cast<CEconItemDefinition*>(params[1]);
 
 	if (pItemDefinition)
 	{
-		size_t numBytes;
+		size_t numBytes = 0;
 		const char* sBuf = pItemDefinition->GetClassName();
 
-		pContext->StringToLocalUTF8(params[2], params[3], sBuf ? sBuf : "", &numBytes);
+		if (sBuf)
+		{
+			pContext->StringToLocalUTF8(params[2], params[3], sBuf, &numBytes);
+		}
 
 		return numBytes;
 	}
@@ -588,6 +654,27 @@ static cell_t PTaH_GetAccountID(IPluginContext* pContext, const cell_t* params)
 	if (pItemView)
 	{
 		return pItemView->GetAccountID();
+	}
+
+	return pContext->ThrowNativeError("CEconItemView == nullptr");
+}
+
+static cell_t PTaH_GetItemID(IPluginContext* pContext, const cell_t* params)
+{
+	CEconItemView* pItemView = reinterpret_cast<CEconItemView*>(params[1]);
+
+	if(pItemView)
+	{
+		cell_t *pItemID;
+
+		uint64_t iItemID = pItemView->GetItemID();
+
+		pContext->LocalToPhysAddr(params[2], &pItemID);
+
+		pItemID[0] = iItemID & 0xFFFFFFFF;
+		pItemID[1] = iItemID >> 32;
+
+		return 0;
 	}
 
 	return pContext->ThrowNativeError("CEconItemView == nullptr");
@@ -802,6 +889,8 @@ extern const sp_nativeinfo_t g_ExtensionNatives[] =
 	{ "CEconItemDefinition.GetDefinitionIndex",				PTaH_GetDefinitionIndex },
 	{ "CEconItemDefinition.GetLoadoutSlot",					PTaH_GetLoadoutSlot },
 	{ "CEconItemDefinition.GetNumSupportedStickerSlots",	PTaH_GetNumSupportedStickerSlots },
+	{ "CEconItemDefinition.GetEconImage",					PTaH_GetEconImage },
+	{ "CEconItemDefinition.GetModel",						PTaH_GetModel },
 	{ "CEconItemDefinition.GetClassName",					PTaH_GetClassName },
 	{ "CEconItemView.GetCustomPaintKitIndex",				PTaH_GetCustomPaintKitIndex },
 	{ "CEconItemView.GetCustomPaintKitSeed",				PTaH_GetCustomPaintKitSeed },
@@ -810,6 +899,7 @@ extern const sp_nativeinfo_t g_ExtensionNatives[] =
 	{ "CEconItemView.IsTradable",							PTaH_IsTradable },
 	{ "CEconItemView.IsMarketable",							PTaH_IsMarketable },
 	{ "CEconItemView.GetItemDefinition",					PTaH_GetItemDefinition },
+	{ "CEconItemView.GetItemID",							PTaH_GetItemID },
 	{ "CEconItemView.GetAccountID",							PTaH_GetAccountID },
 	{ "CEconItemView.GetQuality",							PTaH_GetQuality },
 	{ "CEconItemView.GetRarity",							PTaH_GetRarity },

--- a/natives.cpp
+++ b/natives.cpp
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod P Tools and Hooks Extension
- * Copyright (C) 2016-2019 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
+ * Copyright (C) 2016-2020 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -75,7 +75,7 @@ static cell_t PTaH_GetItemDefinitionByDefIndex(IPluginContext* pContext, const c
 	return 0;
 }
 
-static cell_t PTaH_GetItemInLoadout(IPluginContext* pContext, const cell_t* params)
+static cell_t PTaH_GetItemInLoadoutDeprecated(IPluginContext* pContext, const cell_t* params)
 {
 	IGamePlayer* pPlayer = playerhelpers->GetGamePlayer(params[1]);
 
@@ -89,44 +89,18 @@ static cell_t PTaH_GetItemInLoadout(IPluginContext* pContext, const cell_t* para
 		return pContext->ThrowNativeError("Client %d is not in game", params[1]);
 	}
 
-	static int iGetItemInLoadoutOffset = -1, iInventoryOffset = -1;
-
-	if (iGetItemInLoadoutOffset == -1 || iInventoryOffset == -1)
-	{
-		if (!g_pGameConf[GameConf_CSST]->GetOffset("GetItemInLoadout", &iGetItemInLoadoutOffset))
-		{
-			smutils->LogError(myself, "Failed to get GetItemInLoadout offset.");
-
-			return 0;
-		}
-
-		void* addr = nullptr;
-
-		if (!g_pGameConf[GameConf_CSST]->GetOffset("CCSPlayerInventoryOffset", &iInventoryOffset))
-		{
-			smutils->LogError(myself, "Failed to get CCSPlayerInventoryOffset offset.");
-
-			return 0;
-		}
-
-		if (!g_pGameConf[GameConf_CSST]->GetMemSig("HandleCommand_Buy_Internal", &addr))
-		{
-			smutils->LogError(myself, "Failed to get HandleCommand_Buy_Internal address.");
-
-			return 0;
-		}
-
-		iInventoryOffset = *(int*)((intptr_t)addr + iInventoryOffset);
-	}
-
 	CBaseEntity* pEntity = gamehelpers->ReferenceToEntity(params[1]);
 
-	void* pCCSPlayerInventory = (void*)((intptr_t)pEntity + iInventoryOffset);
+	CCSPlayerInventory* pPlayerInventory = CCSPlayerInventory::FromPlayer(pEntity);
 
-	CEconItemView* pItemView = ((CEconItemView * (VCallingConvention*)(void*, int, int))(*(void***)pCCSPlayerInventory)[iGetItemInLoadoutOffset])
-		(pCCSPlayerInventory, params[2], params[3]);
+	if (pPlayerInventory)
+	{
+		CEconItemView* pItemView = pPlayerInventory->GetItemInLoadout(params[2], params[3]);
 
-	return reinterpret_cast<cell_t>(pItemView);
+		return reinterpret_cast<cell_t>(pItemView);
+	}
+
+	return 0;
 }
 
 //https://github.com/alliedmodders/sourcemod/blob/0c8e6e29184bf58851954019a2060d84f0c556f9/extensions/sdkhooks/util.cpp#L37
@@ -163,7 +137,7 @@ bool UTIL_ContainsDataTable(SendTable* pTable, const char* name)
 }
 
 //Thank you GoD-Tony https://github.com/komashchenko/PTaH/pull/1
-static cell_t PTaH_GetEconItemViewFromWeapon(IPluginContext* pContext, const cell_t* params)
+static cell_t PTaH_GetEconItemViewFromEconEntity(IPluginContext* pContext, const cell_t* params)
 {
 	CBaseEntity* pEntity = gamehelpers->ReferenceToEntity(params[1]);
 
@@ -174,9 +148,9 @@ static cell_t PTaH_GetEconItemViewFromWeapon(IPluginContext* pContext, const cel
 
 	IServerNetworkable* pNet = reinterpret_cast<IServerUnknown*>(pEntity)->GetNetworkable();
 
-	if (!pNet || !UTIL_ContainsDataTable(pNet->GetServerClass()->m_pTable, "DT_BaseCombatWeapon"))
+	if (!pNet || !UTIL_ContainsDataTable(pNet->GetServerClass()->m_pTable, "DT_EconEntity"))
 	{
-		return pContext->ThrowNativeError("Entity %d is not weapon", params[1]);
+		return pContext->ThrowNativeError("Entity %d is not CEconEntity", params[1]);
 	}
 
 	static unsigned int offset = 0;
@@ -189,6 +163,27 @@ static cell_t PTaH_GetEconItemViewFromWeapon(IPluginContext* pContext, const cel
 	}
 
 	return reinterpret_cast<cell_t>(pEntity) + offset;
+}
+
+static cell_t PTaH_GetPlayerInventory(IPluginContext* pContext, const cell_t* params)
+{
+	IGamePlayer* pPlayer = playerhelpers->GetGamePlayer(params[1]);
+
+	if (!pPlayer)
+	{
+		return pContext->ThrowNativeError("Client index %d is invalid", params[1]);
+	}
+
+	if (!pPlayer->IsInGame())
+	{
+		return pContext->ThrowNativeError("Client %d is not in game", params[1]);
+	}
+
+	CBaseEntity* pEntity = gamehelpers->ReferenceToEntity(params[1]);
+
+	CCSPlayerInventory* pPlayerInventory = CCSPlayerInventory::FromPlayer(pEntity);
+
+	return reinterpret_cast<cell_t>(pPlayerInventory);
 }
 
 static cell_t PTaH_GivePlayerItem(IPluginContext* pContext, const cell_t* params)
@@ -646,18 +641,6 @@ static cell_t PTaH_GetOrigin(IPluginContext* pContext, const cell_t* params)
 	return pContext->ThrowNativeError("CEconItemView == nullptr");
 }
 
-static cell_t PTaH_GetKillEater(IPluginContext* pContext, const cell_t* params)
-{
-	CEconItemView* pItemView = reinterpret_cast<CEconItemView*>(params[1]);
-
-	if (pItemView)
-	{
-		return pItemView->GetKillEaterValue();
-	}
-
-	return pContext->ThrowNativeError("CEconItemView == nullptr");
-}
-
 static cell_t PTaH_GetCustomName(IPluginContext* pContext, const cell_t* params)
 {
 	CEconItemView* pItemView = reinterpret_cast<CEconItemView*>(params[1]);
@@ -675,6 +658,134 @@ static cell_t PTaH_GetCustomName(IPluginContext* pContext, const cell_t* params)
 	return pContext->ThrowNativeError("CEconItemView == nullptr");
 }
 
+static cell_t PTaH_GetKillEater(IPluginContext* pContext, const cell_t* params)
+{
+	CEconItemView* pItemView = reinterpret_cast<CEconItemView*>(params[1]);
+
+	if (pItemView)
+	{
+		return pItemView->GetKillEaterValue();
+	}
+
+	return pContext->ThrowNativeError("CEconItemView == nullptr");
+}
+
+static cell_t PTaH_GetAttributeValueByIndex(IPluginContext* pContext, const cell_t* params)
+{
+	CEconItemView* pItemView = reinterpret_cast<CEconItemView*>(params[1]);
+
+	if (pItemView)
+	{
+		if (g_pCEconItemSchema)
+		{
+			CEconItemAttributeDefinition* pItemAttrDef = g_pCEconItemSchema->GetAttributeDefinitionByDefIndex(params[2]);
+
+			if (!pItemAttrDef)
+			{
+				return pContext->ThrowNativeError("Attribute index %d is invalid", params[2]);
+			}
+
+			cell_t* pValue;
+
+			pContext->LocalToPhysAddr(params[3], &pValue);
+
+			if (pItemAttrDef->IsAttributeType<CSchemaAttributeType_Float>())
+			{
+				CAttributeIterator_GetTypedAttributeValue<float, float> it(pItemAttrDef, reinterpret_cast<float*>(pValue));
+				
+				pItemView->IterateAttributes(&it);
+
+				if (it.m_found)
+				{
+					return 1;
+				}
+			}
+			else
+			{
+				CAttributeIterator_GetTypedAttributeValue<unsigned int, unsigned int> it(pItemAttrDef, reinterpret_cast<unsigned int*>(pValue));
+
+				pItemView->IterateAttributes(&it);
+
+				if (it.m_found)
+				{
+					return 1;
+				}
+			}
+		}
+		else
+		{
+			smutils->LogError(myself, "g_pCEconItemSchema == nullptr.");
+		}
+
+		return 0;
+	}
+
+	return pContext->ThrowNativeError("CEconItemView == nullptr");
+}
+
+static cell_t PTaH_GetItemInLoadout(IPluginContext* pContext, const cell_t* params)
+{
+	CCSPlayerInventory* pPlayerInventory = reinterpret_cast<CCSPlayerInventory*>(params[1]);
+
+	if (pPlayerInventory)
+	{
+		CEconItemView* pItemView = pPlayerInventory->GetItemInLoadout(params[2], params[3]);
+
+		return reinterpret_cast<cell_t>(pItemView);
+	}
+
+	return pContext->ThrowNativeError("CCSPlayerInventory == nullptr");
+}
+
+static cell_t PTaH_GetItemsCount(IPluginContext* pContext, const cell_t* params)
+{
+	CCSPlayerInventory* pPlayerInventory = reinterpret_cast<CCSPlayerInventory*>(params[1]);
+
+	if (pPlayerInventory)
+	{
+		CUtlVector<CEconItemView*>* pItems = pPlayerInventory->GetItems();
+
+		if (pItems)
+		{
+			return pItems->Count();
+		}
+
+		return 0;
+	}
+
+	return pContext->ThrowNativeError("CCSPlayerInventory == nullptr");
+}
+
+static cell_t PTaH_GetItem(IPluginContext* pContext, const cell_t* params)
+{
+	CCSPlayerInventory* pPlayerInventory = reinterpret_cast<CCSPlayerInventory*>(params[1]);
+
+	if (pPlayerInventory)
+	{
+		CUtlVector<CEconItemView*>* pItems = pPlayerInventory->GetItems();
+
+		if (pItems)
+		{
+			int iIndex = params[2];
+
+			if (iIndex >= 0 && iIndex < pItems->Count())
+			{
+				CEconItemView* pItemView = pItems->Element(iIndex);
+
+				return reinterpret_cast<cell_t>(pItemView);
+			}
+			else
+			{
+				return pContext->ThrowNativeError("Item index %d is invalid", iIndex);
+			}
+		}
+
+		return 0;
+	}
+
+	return pContext->ThrowNativeError("CCSPlayerInventory == nullptr");
+}
+
 
 extern const sp_nativeinfo_t g_ExtensionNatives[] =
 {
@@ -682,8 +793,8 @@ extern const sp_nativeinfo_t g_ExtensionNatives[] =
 	{ "PTaH",												PTaH_ },
 	{ "PTaH_GetItemDefinitionByName",						PTaH_GetItemDefinitionByName },
 	{ "PTaH_GetItemDefinitionByDefIndex",					PTaH_GetItemDefinitionByDefIndex },
-	{ "PTaH_GetItemInLoadout",								PTaH_GetItemInLoadout },
-	{ "PTaH_GetEconItemViewFromWeapon",						PTaH_GetEconItemViewFromWeapon },
+	{ "PTaH_GetEconItemViewFromEconEntity",					PTaH_GetEconItemViewFromEconEntity },
+	{ "PTaH_GetPlayerInventory",							PTaH_GetPlayerInventory },
 	{ "PTaH_GivePlayerItem",								PTaH_GivePlayerItem },
 	{ "PTaH_ForceFullUpdate",								PTaH_ForceFullUpdate },
 	{ "PTaH_SpawnItemFromDefIndex",							PTaH_SpawnItemFromDefIndex },
@@ -706,5 +817,12 @@ extern const sp_nativeinfo_t g_ExtensionNatives[] =
 	{ "CEconItemView.GetOrigin",							PTaH_GetOrigin },
 	{ "CEconItemView.GetCustomName",						PTaH_GetCustomName },
 	{ "CEconItemView.GetStatTrakKill",						PTaH_GetKillEater },
+	{ "CEconItemView.GetAttributeValueByIndex",				PTaH_GetAttributeValueByIndex },
+	{ "CCSPlayerInventory.GetItemInLoadout",				PTaH_GetItemInLoadout },
+	{ "CCSPlayerInventory.GetItemsCount",					PTaH_GetItemsCount },
+	{ "CCSPlayerInventory.GetItem",							PTaH_GetItem },
+	// Deprecated
+	{ "PTaH_GetItemInLoadout",								PTaH_GetItemInLoadoutDeprecated },
+	{ "PTaH_GetEconItemViewFromWeapon",						PTaH_GetEconItemViewFromEconEntity },
 	{ nullptr,												nullptr }
 };

--- a/natives.h
+++ b/natives.h
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod P Tools and Hooks Extension
- * Copyright (C) 2016-2019 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
+ * Copyright (C) 2016-2020 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/smsdk_config.h
+++ b/smsdk_config.h
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod P Tools and Hooks Extension
- * Copyright (C) 2016-2019 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
+ * Copyright (C) 2016-2020 Phoenix (˙·٠●Феникс●٠·˙).  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -29,8 +29,8 @@
 /* Basic information exposed publicly */
 #define SMEXT_CONF_NAME			"PTaH"
 #define SMEXT_CONF_DESCRIPTION	"Additional CS:GO Hooks and Natives"
-#define SMEXT_CONF_VERSION		"1.1.1"
-#define PTaH_VERSION			101010
+#define SMEXT_CONF_VERSION		"1.1.2"
+#define PTaH_VERSION			101020
 #define SMEXT_CONF_AUTHOR		"Phoenix (˙·٠●Феникс●٠·˙)"
 #define SMEXT_CONF_URL			"https://zizt.ru/ | https://hlmod.ru"
 #define SMEXT_CONF_LOGTAG		"PTaH"


### PR DESCRIPTION
Fixed crash if there were no necessary values ​​in GameData
Added:
Natives
  PTaH_GetPlayerInventory
  CCSPlayerInventory.GetItemInLoadout
  CCSPlayerInventory.GetItemsCount
  CCSPlayerInventory.GetItem
  CEconItemView.GetAttributeValueByIndex
  CEconItemDefinition.GetEconImage
  CEconItemDefinition.GetModel
  CEconItemView.GetItemID
Hook
  InventoryUpdate

Outdated
PTaH_GetItemInLoadout
PTaH_GetEconItemViewFromWeapon